### PR TITLE
Add module account_analytic_plan_required

### DIFF
--- a/account_analytic_plan_required/__init__.py
+++ b/account_analytic_plan_required/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account analytic plan required module for OpenERP
+#    Copyright (C) 2014 Acsone (http://acsone.eu).
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import account

--- a/account_analytic_plan_required/__openerp__.py
+++ b/account_analytic_plan_required/__openerp__.py
@@ -1,0 +1,47 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account analytic plan required module for OpenERP
+#    Copyright (C) 2014 Acsone (http://acsone.eu).
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Account Analytic Plan Required',
+    'version': '0.1',
+    'category': 'Analytic Accounting',
+    'license': 'AGPL-3',
+    'description': """
+Account Analytic Plan Required
+==============================
+
+This module extends account_analytic_required and adds 2 policies to
+control the use of analytic distributions. The policies behave as follow
+* never: no analytic account nor analytic distribution allowed
+* always: analytic account required
+* always_plan: analytic_distribution required
+* always_plan_or_account: analytic distribution or analytic account required
+* optional: do what you like,
+
+In any case analytic account and analytic distribution are mutually exclusive.
+""",
+    'author': 'ACSONE SA/NV',
+    'website': 'http://www.acsone.eu/',
+    'depends': ['account_analytic_required', 'account_analytic_plans'],
+    'data': [],
+    'installable': True,
+}

--- a/account_analytic_plan_required/account.py
+++ b/account_analytic_plan_required/account.py
@@ -41,11 +41,7 @@ class account_account_type(orm.Model):
 class account_move_line(orm.Model):
     _inherit = "account.move.line"
 
-    def _check_analytic_required_msg(self, cr, uid, ids, context=None):
-        msg = super(account_move_line, self).\
-            _check_analytic_required_msg(cr, uid, ids, context=context)
-        if msg:
-            return msg
+    def _check_analytic_plan_required_msg(self, cr, uid, ids, context=None):
         for move_line in self.browse(cr, uid, ids, context=context):
             if move_line.analytic_account_id and move_line.analytics_id:
                 return _('Analytic account and analytic distribution '
@@ -87,12 +83,12 @@ class account_move_line(orm.Model):
                          move_line.analytic_account_id.code,
                          move_line.analytic_account_id.name)
 
-    def _check_analytic_required(self, cr, uid, ids, context=None):
-        return not self._check_analytic_required_msg(cr, uid, ids,
-                                                     context=context)
+    def _check_analytic_plan_required(self, cr, uid, ids, context=None):
+        return not self._check_analytic_plan_required_msg(cr, uid, ids,
+                                                          context=context)
 
     _constraints = [
-        (_check_analytic_required,
-         _check_analytic_required_msg,
-         ['analytic_account_id', 'analytics_id']),
+        (_check_analytic_plan_required,
+         _check_analytic_plan_required_msg,
+         ['analytic_account_id', 'analytics_id', 'account_id']),
     ]

--- a/account_analytic_plan_required/account.py
+++ b/account_analytic_plan_required/account.py
@@ -90,5 +90,6 @@ class account_move_line(orm.Model):
     _constraints = [
         (_check_analytic_plan_required,
          _check_analytic_plan_required_msg,
-         ['analytic_account_id', 'analytics_id', 'account_id']),
+         ['analytic_account_id', 'analytics_id', 'account_id',
+          'debit', 'credit']),
     ]

--- a/account_analytic_plan_required/account.py
+++ b/account_analytic_plan_required/account.py
@@ -20,30 +20,22 @@
 #
 ##############################################################################
 
-from openerp.osv import orm, fields
+from openerp.osv import orm
 from openerp.tools.translate import _
 
 
 class account_account_type(orm.Model):
     _inherit = "account.account.type"
 
-    _columns = {
-        'analytic_policy': fields.selection([
-            ('optional', 'Optional'),
-            ('always', 'Always (analytic account)'),
-            ('always_plan', 'Always (analytic distribution)'),
-            ('always_plan_or_account',
-             'Always (analytic account or distribution)'),
-            ('never', 'Never')
-            ], 'Policy for analytic account',
-            help="Set the policy for analytic accounts : if you select "
-            "'Optional', the accountant is free to put an analytic account "
-            "on an account move line with this type of account ; if you "
-            "select 'Always', the accountant will get an error message if "
-            "there is no analytic account ; if you select 'Never', the "
-            "accountant will get an error message if an analytic account "
-            "is present."),  # TODO: help
-    }
+    def _get_policies(self, cr, uid, context=None):
+        """This is the method to be inherited for adding policies"""
+        policies = super(account_account_type, self).\
+            _get_policies(cr, uid, context=context)
+        policies.extend([('always_plan',
+                          'Always (analytic distribution)'),
+                         ('always_plan_or_account',
+                          'Always (analytic account or distribution)')])
+        return policies
 
 
 class account_move_line(orm.Model):

--- a/account_analytic_plan_required/account.py
+++ b/account_analytic_plan_required/account.py
@@ -80,11 +80,11 @@ class account_move_line(orm.Model):
                 return _("Analytic policy is set to 'Never' with account "
                          "%s '%s' but the account move line with label "
                          "'%s' has an analytic distribution %s '%s'.") % \
-                       (move_line.account_id.code,
-                        move_line.account_id.name,
-                        move_line.name,
-                        move_line.analytic_account_id.code,
-                        move_line.analytic_account_id.name)
+                        (move_line.account_id.code,
+                         move_line.account_id.name,
+                         move_line.name,
+                         move_line.analytic_account_id.code,
+                         move_line.analytic_account_id.name)
 
     def _check_analytic_required(self, cr, uid, ids, context=None):
         return not self._check_analytic_required_msg(cr, uid, ids,

--- a/account_analytic_plan_required/account.py
+++ b/account_analytic_plan_required/account.py
@@ -1,0 +1,105 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account analytic plan required module for OpenERP
+#    Copyright (C) 2014 Acsone (http://acsone.eu).
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from openerp.tools.translate import _
+
+
+class account_account_type(orm.Model):
+    _inherit = "account.account.type"
+
+    _columns = {
+        'analytic_policy': fields.selection([
+            ('optional', 'Optional'),
+            ('always', 'Always (analytic account)'),
+            ('always_plan', 'Always (analytic distribution)'),
+            ('always_plan_or_account',
+             'Always (analytic account or distribution)'),
+            ('never', 'Never')
+            ], 'Policy for analytic account',
+            help="Set the policy for analytic accounts : if you select "
+            "'Optional', the accountant is free to put an analytic account "
+            "on an account move line with this type of account ; if you "
+            "select 'Always', the accountant will get an error message if "
+            "there is no analytic account ; if you select 'Never', the "
+            "accountant will get an error message if an analytic account "
+            "is present."),  # TODO: help
+    }
+
+
+class account_move_line(orm.Model):
+    _inherit = "account.move.line"
+
+    def _check_analytic_required_msg(self, cr, uid, ids, context=None):
+        msg = super(account_move_line, self).\
+            _check_analytic_required_msg(cr, uid, ids, context=context)
+        if msg:
+            return msg
+        for move_line in self.browse(cr, uid, ids, context=context):
+            if move_line.analytic_account_id and move_line.analytics_id:
+                return _('Analytic account and analytic distribution '
+                         'are mutually exclusive')
+            if move_line.debit == 0 and move_line.credit == 0:
+                continue
+            analytic_policy = \
+                move_line.account_id.user_type.analytic_policy
+            if analytic_policy == 'always_plan' \
+                    and not move_line.analytics_id:
+                return _("Analytic policy is set to "
+                         "'Always (analytic distribution)' with account "
+                         "%s '%s' but the analytic distribution is "
+                         "missing in the account move line with "
+                         "label '%s'.") % \
+                        (move_line.account_id.code,
+                         move_line.account_id.name,
+                         move_line.name)
+            if analytic_policy == 'always_plan_or_account' \
+                    and not move_line.analytic_account_id \
+                    and not move_line.analytics_id:
+                return _("Analytic policy is set to "
+                         "'Always (analytic account or distribution)' "
+                         "with account %s '%s' but the analytic "
+                         "distribution and the analytic account are "
+                         "missing in the account move line "
+                         "with label '%s'.") % \
+                        (move_line.account_id.code,
+                         move_line.account_id.name,
+                         move_line.name)
+            elif analytic_policy == 'never' and move_line.analytics_id:
+                return _("Analytic policy is set to 'Never' with account "
+                         "%s '%s' but the account move line with label "
+                         "'%s' has an analytic distribution %s '%s'.") % \
+                       (move_line.account_id.code,
+                        move_line.account_id.name,
+                        move_line.name,
+                        move_line.analytic_account_id.code,
+                        move_line.analytic_account_id.name)
+
+    def _check_analytic_required(self, cr, uid, ids, context=None):
+        return not self._check_analytic_required_msg(cr, uid, ids,
+                                                     context=context)
+
+    _constraints = [
+        (_check_analytic_required,
+         _check_analytic_required_msg,
+         ['analytic_account_id', 'analytics_id']),
+    ]

--- a/account_analytic_plan_required/account.py
+++ b/account_analytic_plan_required/account.py
@@ -52,8 +52,9 @@ class account_move_line(orm.Model):
                          'are mutually exclusive')
             if move_line.debit == 0 and move_line.credit == 0:
                 continue
-            analytic_policy = \
-                move_line.account_id.user_type.analytic_policy
+            analytic_policy = self._get_analytic_policy(cr, uid,
+                                                        move_line.account_id,
+                                                        context=context)
             if analytic_policy == 'always_plan' \
                     and not move_line.analytics_id:
                 return _("Analytic policy is set to "

--- a/account_analytic_plan_required/tests/__init__.py
+++ b/account_analytic_plan_required/tests/__init__.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account analytic plan required module for OpenERP
+#    Copyright (C) 2014 Acsone (http://acsone.eu).
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_account_analytic_plan_required
+
+fast_suite = [
+]
+
+checks = [
+    test_account_analytic_plan_required,
+]

--- a/account_analytic_plan_required/tests/test_account_analytic_plan_required.py
+++ b/account_analytic_plan_required/tests/test_account_analytic_plan_required.py
@@ -1,0 +1,188 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account analytic plan required module for OpenERP
+#    Copyright (C) 2014 Acsone (http://acsone.eu).
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from datetime import datetime
+
+from openerp.tests import common
+from openerp.osv import orm
+
+
+class test_account_analytic_plan_required(common.TransactionCase):
+
+    def setUp(self):
+        super(test_account_analytic_plan_required, self).setUp()
+        self.account_obj = self.registry('account.account')
+        self.account_type_obj = self.registry('account.account.type')
+        self.move_obj = self.registry('account.move')
+        self.move_line_obj = self.registry('account.move.line')
+        self.analytic_account_obj = self.registry('account.analytic.account')
+        self.analytic_distribution_obj = \
+            self.registry('account.analytic.plan.instance')
+        self.analytic_account_id = self.analytic_account_obj.create(
+            self.cr, self.uid, {'name': 'test aa', 'type': 'normal'})
+        self.analytic_distribution_id = self.analytic_distribution_obj.create(
+            self.cr, self.uid, {'name': 'test ad'})
+
+    def _create_move(self, with_analytic, with_analytic_plan, amount=100):
+        date = datetime.now()
+        period_id = self.registry('account.period').find(
+            self.cr, self.uid, date,
+            context={'account_period_prefer_normal': True})[0]
+        move_vals = {
+            'journal_id': self.ref('account.sales_journal'),
+            'period_id': period_id,
+            'date': date,
+        }
+        move_id = self.move_obj.create(self.cr, self.uid, move_vals)
+        move_line_id = self.move_line_obj.create(
+            self.cr, self.uid,
+            {'move_id': move_id,
+             'name': '/',
+             'debit': 0,
+             'credit': amount,
+             'account_id': self.ref('account.a_sale'),
+             'analytic_account_id':
+                  self.analytic_account_id if with_analytic else False,
+             'analytics_id':
+                  self.analytic_distribution_id if with_analytic_plan else False})
+        self.move_line_obj.create(
+            self.cr, self.uid,
+            {'move_id': move_id,
+             'name': '/',
+             'debit': amount,
+             'credit': 0,
+             'account_id': self.ref('account.a_recv')})
+        return move_line_id
+
+    def _set_analytic_policy(self, policy, aref='account.a_sale'):
+        account_type = self.account_obj.browse(self.cr, self.uid,
+                                               self.ref(aref)).user_type
+        self.account_type_obj.write(self.cr, self.uid, account_type.id,
+                                    {'analytic_policy': policy})
+
+    def test_optional(self):
+        self._create_move(with_analytic=False, with_analytic_plan=False)
+        self._create_move(with_analytic=True, with_analytic_plan=False)
+        self._create_move(with_analytic=False, with_analytic_plan=True)
+
+    def test_exclusive(self):
+        with self.assertRaises(orm.except_orm):
+            self._create_move(with_analytic=True, with_analytic_plan=True)
+
+    def test_always_no_analytic(self):
+        self._set_analytic_policy('always')
+        with self.assertRaises(orm.except_orm):
+            self._create_move(with_analytic=False, with_analytic_plan=False)
+        with self.assertRaises(orm.except_orm):
+            self._create_move(with_analytic=False, with_analytic_plan=True)
+
+    def test_always_no_analytic_0(self):
+        # accept missing analytic account when debit=credit=0
+        self._set_analytic_policy('always')
+        self._create_move(with_analytic=False, with_analytic_plan=False,
+                          amount=0)
+
+    def test_always_with_analytic(self):
+        self._set_analytic_policy('always')
+        self._create_move(with_analytic=True, with_analytic_plan=False)
+
+    def test_always_plan_no_analytic_plan(self):
+        self._set_analytic_policy('always_plan')
+        with self.assertRaises(orm.except_orm):
+            self._create_move(with_analytic=False, with_analytic_plan=False)
+        with self.assertRaises(orm.except_orm):
+            self._create_move(with_analytic=True, with_analytic_plan=False)
+
+    def test_always_plan_no_analytic_plan_0(self):
+        # accept missing analytic distribution when debit=credit=0
+        self._set_analytic_policy('always_plan')
+        self._create_move(with_analytic=False, with_analytic_plan=False,
+                          amount=0)
+
+    def test_always_plan_with_analytic_plan(self):
+        self._set_analytic_policy('always_plan')
+        self._create_move(with_analytic=False, with_analytic_plan=True)
+
+    def test_always_plan_or_account_nothing(self):
+        self._set_analytic_policy('always_plan_or_account')
+        with self.assertRaises(orm.except_orm):
+            self._create_move(with_analytic=False, with_analytic_plan=False)
+
+    def test_always_plan_or_account_no_analytic_plan_0(self):
+        # accept missing analytic distribution when debit=credit=0
+        self._set_analytic_policy('always_plan_or_account')
+        self._create_move(with_analytic=False, with_analytic_plan=False,
+                          amount=0)
+        self._create_move(with_analytic=True, with_analytic_plan=False,
+                          amount=0)
+        self._create_move(with_analytic=False, with_analytic_plan=True,
+                          amount=0)
+
+    def test_always_plan_or_account_with(self):
+        self._set_analytic_policy('always_plan_or_account')
+        self._create_move(with_analytic=False, with_analytic_plan=True)
+        self._create_move(with_analytic=True, with_analytic_plan=False)
+
+    def test_never_no_analytic(self):
+        self._set_analytic_policy('never')
+        self._create_move(with_analytic=False, with_analytic_plan=False)
+
+    def test_never_with_analytic(self):
+        self._set_analytic_policy('never')
+        with self.assertRaises(orm.except_orm):
+            self._create_move(with_analytic=True, with_analytic_plan=False)
+        with self.assertRaises(orm.except_orm):
+            self._create_move(with_analytic=False, with_analytic_plan=True)
+
+    def test_never_with_analytic_0(self):
+        # accept analytic when debit=credit=0
+        self._set_analytic_policy('never')
+        self._create_move(with_analytic=True, with_analytic_plan=False,
+                          amount=0)
+        self._create_move(with_analytic=False, with_analytic_plan=True,
+                          amount=0)
+
+    def test_always_remove_analytic_plan(self):
+        # remove analytic plan account when policy is always
+        self._set_analytic_policy('always_plan')
+        line_id = self._create_move(with_analytic=False,
+                                    with_analytic_plan=True)
+        with self.assertRaises(orm.except_orm):
+            self.move_line_obj.write(self.cr, self.uid, line_id,
+                                     {'analytics_id': False})
+
+    def test_change_account(self):
+        self._set_analytic_policy('always_plan', aref='account.a_expense')
+        line_id = self._create_move(with_analytic=False,
+                                    with_analytic_plan=False)
+        # change account to a_expense with policy always_plan but missing
+        # analytic distribution
+        with self.assertRaises(orm.except_orm):
+            self.move_line_obj.write(
+                self.cr, self.uid, line_id,
+                {'account_id': self.ref('account.a_expense')})
+        # change account to a_expense with policy always_plan
+        # with analytic distribution -> ok
+        self.move_line_obj.write(
+            self.cr, self.uid, line_id, {
+                'account_id': self.ref('account.a_expense'),
+                'analytics_id': self.analytic_distribution_id})

--- a/account_analytic_plan_required/tests/test_account_analytic_plan_required.py
+++ b/account_analytic_plan_required/tests/test_account_analytic_plan_required.py
@@ -61,9 +61,9 @@ class test_account_analytic_plan_required(common.TransactionCase):
              'credit': amount,
              'account_id': self.ref('account.a_sale'),
              'analytic_account_id':
-                  self.analytic_account_id if with_analytic else False,
+             self.analytic_account_id if with_analytic else False,
              'analytics_id':
-                  self.analytic_distribution_id if with_analytic_plan else False})
+             self.analytic_distribution_id if with_analytic_plan else False})
         self.move_line_obj.create(
             self.cr, self.uid,
             {'move_id': move_id,

--- a/account_analytic_plan_required/tests/test_account_analytic_plan_required.py
+++ b/account_analytic_plan_required/tests/test_account_analytic_plan_required.py
@@ -167,7 +167,7 @@ class test_account_analytic_plan_required(common.TransactionCase):
         line_id = self._create_move(with_analytic=False,
                                     with_analytic_plan=True)
         with self.assertRaises(orm.except_orm):
-            self.move_line_obj.write(self.cr, self.uid, line_id,
+            self.move_line_obj.write(self.cr, self.uid, [line_id],
                                      {'analytics_id': False})
 
     def test_change_account(self):
@@ -178,11 +178,11 @@ class test_account_analytic_plan_required(common.TransactionCase):
         # analytic distribution
         with self.assertRaises(orm.except_orm):
             self.move_line_obj.write(
-                self.cr, self.uid, line_id,
+                self.cr, self.uid, [line_id],
                 {'account_id': self.ref('account.a_expense')})
         # change account to a_expense with policy always_plan
         # with analytic distribution -> ok
         self.move_line_obj.write(
-            self.cr, self.uid, line_id, {
+            self.cr, self.uid, [line_id], {
                 'account_id': self.ref('account.a_expense'),
                 'analytics_id': self.analytic_distribution_id})

--- a/account_analytic_required/account.py
+++ b/account_analytic_required/account.py
@@ -96,4 +96,4 @@ class account_move_line(orm.Model):
 
     _constraints = [(_check_analytic_required,
                      _check_analytic_required_msg,
-                     ['analytic_account_id', 'account_id'])]
+                     ['analytic_account_id', 'account_id', 'debit', 'credit'])]

--- a/account_analytic_required/account.py
+++ b/account_analytic_required/account.py
@@ -96,4 +96,4 @@ class account_move_line(orm.Model):
 
     _constraints = [(_check_analytic_required,
                      _check_analytic_required_msg,
-                     ['analytic_account_id'])]
+                     ['analytic_account_id', 'account_id'])]

--- a/account_analytic_required/account.py
+++ b/account_analytic_required/account.py
@@ -32,8 +32,7 @@ class account_account_type(orm.Model):
         """This is the method to be inherited for adding policies"""
         return [('optional', 'Optional'),
                 ('always', 'Always'),
-                ('never', 'Never')
-               ]
+                ('never', 'Never')]
 
     def __get_policies(self, cr, uid, context=None):
         """ Call method which can be inherited """
@@ -69,28 +68,26 @@ class account_move_line(orm.Model):
             if analytic_policy == 'always' and \
                     not move_line.analytic_account_id:
                 return _("Analytic policy is set to 'Always' with account "
-                        "%s '%s' but the analytic account is missing in "
-                        "the account move line with label '%s'.") % (
-                        move_line.account_id.code,
-                        move_line.account_id.name,
-                        move_line.name)
+                         "%s '%s' but the analytic account is missing in "
+                         "the account move line with label '%s'.") % \
+                        (move_line.account_id.code,
+                         move_line.account_id.name,
+                         move_line.name)
             elif analytic_policy == 'never' and \
                     move_line.analytic_account_id:
                 return _("Analytic policy is set to 'Never' with account %s "
-                        "'%s' but the account move line with label '%s' "
-                        "has an analytic account %s '%s'.") % (
-                        move_line.account_id.code,
-                        move_line.account_id.name,
-                        move_line.name,
-                        move_line.analytic_account_id.code,
-                        move_line.analytic_account_id.name)
+                         "'%s' but the account move line with label '%s' "
+                         "has an analytic account %s '%s'.") % \
+                        (move_line.account_id.code,
+                         move_line.account_id.name,
+                         move_line.name,
+                         move_line.analytic_account_id.code,
+                         move_line.analytic_account_id.name)
 
     def _check_analytic_required(self, cr, uid, ids, context=None):
         return not self._check_analytic_required_msg(cr, uid, ids,
                                                      context=context)
 
-    _constraints = [
-        (_check_analytic_required,
-         _check_analytic_required_msg,
-         ['analytic_account_id']),
-    ]
+    _constraints = [(_check_analytic_required,
+                     _check_analytic_required_msg,
+                     ['analytic_account_id'])]

--- a/account_analytic_required/account.py
+++ b/account_analytic_required/account.py
@@ -28,12 +28,21 @@ from openerp.tools.translate import _
 class account_account_type(orm.Model):
     _inherit = "account.account.type"
 
+    def _get_policies(self, cr, uid, context=None):
+        """This is the method to be inherited for adding policies"""
+        return [('optional', 'Optional'),
+                ('always', 'Always'),
+                ('never', 'Never')
+               ]
+
+    def __get_policies(self, cr, uid, context=None):
+        """ Call method which can be inherited """
+        return self._get_policies(cr, uid, context=context)
+
     _columns = {
-        'analytic_policy': fields.selection([
-            ('optional', 'Optional'),
-            ('always', 'Always'),
-            ('never', 'Never')
-            ], 'Policy for analytic account',
+        'analytic_policy': fields.selection(
+            __get_policies,
+            'Policy for analytic account',
             help="Set the policy for analytic accounts : if you select "
             "'Optional', the accountant is free to put an analytic account "
             "on an account move line with this type of account ; if you "

--- a/account_analytic_required/account.py
+++ b/account_analytic_required/account.py
@@ -51,53 +51,37 @@ class account_account_type(orm.Model):
 class account_move_line(orm.Model):
     _inherit = "account.move.line"
 
-    def check_analytic_required(self, cr, uid, ids, vals, context=None):
-        if 'account_id' in vals or 'analytic_account_id' in vals or \
-                'debit' in vals or 'credit' in vals:
-            if isinstance(ids, (int, long)):
-                ids = [ids]
-            for move_line in self.browse(cr, uid, ids, context):
-                if move_line.debit == 0 and move_line.credit == 0:
-                    continue
-                analytic_policy = \
-                    move_line.account_id.user_type.analytic_policy
-                if analytic_policy == 'always' and \
-                        not move_line.analytic_account_id:
-                    raise orm.except_orm(
-                        _('Error :'),
-                        _("Analytic policy is set to 'Always' with account "
-                            "%s '%s' but the analytic account is missing in "
-                            "the account move line with label '%s'.")
-                        % (
-                            move_line.account_id.code,
-                            move_line.account_id.name,
-                            move_line.name))
-                elif analytic_policy == 'never' and \
-                        move_line.analytic_account_id:
-                    raise orm.except_orm(
-                        _('Error :'),
-                        _("Analytic policy is set to 'Never' with account %s "
-                            "'%s' but the account move line with label '%s' "
-                            "has an analytic account %s '%s'.")
-                        % (
-                            move_line.account_id.code,
-                            move_line.account_id.name,
-                            move_line.name,
-                            move_line.analytic_account_id.code,
-                            move_line.analytic_account_id.name))
-        return True
+    def _check_analytic_required_msg(self, cr, uid, ids, context=None):
+        for move_line in self.browse(cr, uid, ids, context):
+            if move_line.debit == 0 and move_line.credit == 0:
+                continue
+            analytic_policy = \
+                move_line.account_id.user_type.analytic_policy
+            if analytic_policy == 'always' and \
+                    not move_line.analytic_account_id:
+                return _("Analytic policy is set to 'Always' with account "
+                        "%s '%s' but the analytic account is missing in "
+                        "the account move line with label '%s'.") % (
+                        move_line.account_id.code,
+                        move_line.account_id.name,
+                        move_line.name)
+            elif analytic_policy == 'never' and \
+                    move_line.analytic_account_id:
+                return _("Analytic policy is set to 'Never' with account %s "
+                        "'%s' but the account move line with label '%s' "
+                        "has an analytic account %s '%s'.") % (
+                        move_line.account_id.code,
+                        move_line.account_id.name,
+                        move_line.name,
+                        move_line.analytic_account_id.code,
+                        move_line.analytic_account_id.name)
 
-    def create(self, cr, uid, vals, context=None, check=True):
-        line_id = super(account_move_line, self).create(
-            cr, uid, vals, context=context, check=check)
-        self.check_analytic_required(cr, uid, line_id, vals, context=context)
-        return line_id
+    def _check_analytic_required(self, cr, uid, ids, context=None):
+        return not self._check_analytic_required_msg(cr, uid, ids,
+                                                     context=context)
 
-    def write(
-            self, cr, uid, ids, vals, context=None, check=True,
-            update_check=True):
-        res = super(account_move_line, self).write(
-            cr, uid, ids, vals, context=context, check=check,
-            update_check=update_check)
-        self.check_analytic_required(cr, uid, ids, vals, context=context)
-        return res
+    _constraints = [
+        (_check_analytic_required,
+         _check_analytic_required_msg,
+         ['analytic_account_id']),
+    ]

--- a/account_analytic_required/account.py
+++ b/account_analytic_required/account.py
@@ -42,6 +42,7 @@ class account_account_type(orm.Model):
         'analytic_policy': fields.selection(
             __get_policies,
             'Policy for analytic account',
+            required=True,
             help="Set the policy for analytic accounts : if you select "
             "'Optional', the accountant is free to put an analytic account "
             "on an account move line with this type of account ; if you "
@@ -53,7 +54,7 @@ class account_account_type(orm.Model):
 
     _defaults = {
         'analytic_policy': 'optional',
-        }
+    }
 
 
 class account_move_line(orm.Model):

--- a/account_analytic_required/account.py
+++ b/account_analytic_required/account.py
@@ -59,12 +59,17 @@ class account_account_type(orm.Model):
 class account_move_line(orm.Model):
     _inherit = "account.move.line"
 
+    def _get_analytic_policy(self, cr, uid, account, context=None):
+        """ Extension point to obtain analytic policy for an account """
+        return account.user_type.analytic_policy
+
     def _check_analytic_required_msg(self, cr, uid, ids, context=None):
         for move_line in self.browse(cr, uid, ids, context):
             if move_line.debit == 0 and move_line.credit == 0:
                 continue
-            analytic_policy = \
-                move_line.account_id.user_type.analytic_policy
+            analytic_policy = self._get_analytic_policy(cr, uid,
+                                                        move_line.account_id,
+                                                        context=context)
             if analytic_policy == 'always' and \
                     not move_line.analytic_account_id:
                 return _("Analytic policy is set to 'Always' with account "

--- a/account_analytic_required/tests/test_account_analytic_required.py
+++ b/account_analytic_required/tests/test_account_analytic_required.py
@@ -110,7 +110,7 @@ class test_account_analytic_required(common.TransactionCase):
         self._set_analytic_policy('always')
         line_id = self._create_move(with_analytic=True)
         with self.assertRaises(orm.except_orm):
-            self.move_line_obj.write(self.cr, self.uid, line_id,
+            self.move_line_obj.write(self.cr, self.uid, [line_id],
                                      {'analytic_account_id': False})
 
     def test_change_account(self):
@@ -120,11 +120,11 @@ class test_account_analytic_required(common.TransactionCase):
         # analytic_account
         with self.assertRaises(orm.except_orm):
             self.move_line_obj.write(
-                self.cr, self.uid, line_id,
+                self.cr, self.uid, [line_id],
                 {'account_id': self.ref('account.a_expense')})
         # change account to a_expense with policy always
         # with analytic account -> ok
         self.move_line_obj.write(
-            self.cr, self.uid, line_id, {
+            self.cr, self.uid, [line_id], {
                 'account_id': self.ref('account.a_expense'),
                 'analytic_account_id': self.analytic_account_id})


### PR DESCRIPTION
This module is an extension to account_analytic_required to support analytic distributions. 

It add two policies:
- always_plan: an analytic distribution is required
- always_plan_or_account: an analytic distribution or an analytic account is required

In addition, this PR includes
- a refactoring of account_analytic_required to use constraints (for readability and robustness).
- a couple of extension points for analytic policies.
