### PR TITLE
[9.0] [FIX] account_analytic_no_lines: stacktrace if invoice with quantity 0

### DIFF
--- a/account_analytic_no_lines/models/account_invoice.py
+++ b/account_analytic_no_lines/models/account_invoice.py
@@ -13,5 +13,7 @@ class AccountInvoice(models.Model):
     def finalize_invoice_move_lines(self, move_lines):
         move_lines = super(AccountInvoice, self)\
             .finalize_invoice_move_lines(move_lines)
-        move_lines[0][2].pop('analytic_line_ids')
+        if move_lines and len(move_lines[0]) > 2 and \
+                'analytic_line_ids' in move_lines[0][2]:
+            move_lines[0][2].pop('analytic_line_ids')
         return move_lines


### PR DESCRIPTION
When validating an invoice with only lines with quantity == 0, account_analytic_no_lines raised a `TupleIndexOutOfRange`.