### PR TITLE
Add 10.0 project task analytic tag

### DIFF
--- a/project_task_analytic_tag/README.rst
+++ b/project_task_analytic_tag/README.rst
@@ -1,0 +1,91 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+Project Task Analytic Tag
+=========================
+
+This module extends the functionality of project to support Tags in timesheet
+and the possibility to add them from the projects.
+
+The target to add analytic tags to project task is to create analytic lines
+(timesheet lines) with right tag.
+
+Also this module combine very well with the dimensions module
+(Analytic Tag Dimensions) for group analytic tags on dimensions.
+
+============
+Installation
+============
+
+To install this module, you need to:
+
+- First Add in the addons path the module and install in your Odoo.
+  And install the dependencies of the module
+
+=============
+Configuration
+=============
+
+To configure this module, you need to:
+
+- You only need to have all the dependencies installed.
+
+=====
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to project and enter in a task section,
+#. Go to the page timesheet
+#. You can add a new element.
+#. When you add the tag in the extra Information, the tag is automatically
+   set for newly added element.
+
+===========
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/project_task_analytic_tag/issues>`_. In case of trouble,
+please check there if your issue has already been reported. If you spotted it
+first, help us smash it by providing detailed and welcomed feedback.
+
+=======
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Luis Adan Jiménez Hernádez <luis.jimenez@pesol.es>
+* Ángel Moya <angel.moya@pesol.es>
+
+Funders
+-------
+
+The development of this module has been financially supported by:
+
+* PESOL
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/project_task_analytic_tag/__init__.py
+++ b/project_task_analytic_tag/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 PESOL (http://pesol.es)
+#                Luis Adan Jimenez Hernandez (luis.jimenez@pesol.es)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import models

--- a/project_task_analytic_tag/__manifest__.py
+++ b/project_task_analytic_tag/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 PESOL (http://pesol.es)
+#                Luis Adan Jimenez Hernandez (luis.jimenez@pesol.es)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Project Task Analytic Tag",
+    "summary": "Analytic tag in project task",
+    "version": "10.0.1.0.0",
+    "author": "PESOL, Odoo Community Association (OCA)",
+    "website": "http://pesol.es",
+    "category": "Analytic Accont",
+    "license": "AGPL-3",
+    "depends": [
+        'project',
+        "hr_timesheet"
+    ],
+    "data": [
+        'views/project_task_analytic_view.xml',
+    ],
+    'installable': True,
+}

--- a/project_task_analytic_tag/models/__init__.py
+++ b/project_task_analytic_tag/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 PESOL (http://pesol.es)
+#                Luis Adan Jimenez Hernandez (luis.jimenez@pesol.es)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import project_task_tag

--- a/project_task_analytic_tag/models/project_task_tag.py
+++ b/project_task_analytic_tag/models/project_task_tag.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 PESOL (http://pesol.es)
+#                Luis Adan Jimenez Hernandez (luis.jimenez@pesol.es)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields
+
+
+class ProjectTaskTag(models.Model):
+    _inherit = 'project.task'
+
+    analytic_tag_ids = fields.Many2many(
+        comodel_name='account.analytic.tag',
+        relation='project_task_analytic_tag_rel',
+        column1='analytic_tag_ids',
+        column2='default_tag_ids',
+        string='Analytic Tag')

--- a/project_task_analytic_tag/tests/__init__.py
+++ b/project_task_analytic_tag/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_project_task

--- a/project_task_analytic_tag/tests/test_project_task.py
+++ b/project_task_analytic_tag/tests/test_project_task.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 PESOL (http://pesol.es)
+#                Angel Moya (angel.moya@pesol.es)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProjectTask(TransactionCase):
+
+    def setUp(self, *args, **kwargs):
+        super(TestProjectTask, self).setUp(*args, **kwargs)
+
+        self.project = self.env.ref(
+            'project.project_project_1')
+
+    def test_create_analytic_line(self):
+        """Test analytic line creation on project task
+        """
+        self.project.write({
+            'timesheet_ids': [(0, 0, {
+                'name': 'test',
+                'tag_ids': [(0, 0, {'name': 'name'})]
+            })],
+        })

--- a/project_task_analytic_tag/views/project_task_analytic_view.xml
+++ b/project_task_analytic_tag/views/project_task_analytic_view.xml
@@ -1,0 +1,28 @@
+<odoo>
+    <record id="view_project_task_analytic_tag_hr" model="ir.ui.view">
+        <field name="name">project.task.analytic.tag.hr.form</field>
+        <field name="model">project.task</field>
+        <field name="type">form</field>
+        <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='timesheet_ids']/tree/field[@name='name']" position="after">
+                <field name="tag_ids" string="Analytic Tag" widget="many2many_tags"/>
+            </xpath>
+            <xpath expr="//field[@name='timesheet_ids']" position="attributes">
+                <attribute name="context">{'default_project_id': project_id,'default_tag_ids': analytic_tag_ids}</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_project_task_analytic_tag" model="ir.ui.view">
+        <field name="name">project.task.analytic.tag.form</field>
+        <field name="model">project.task</field>
+        <field name="type">form</field>
+        <field name="inherit_id" ref="project.view_task_form2"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='date_last_stage_update']" position="after">
+                <field name="analytic_tag_ids" widget="many2many_tags"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION

Project Task Analytic Tag
=========================

This module extends the functionality of project to support to
add Tags in the timesheet and allow you to use the tags of the projects in your timesheet