### PR TITLE
[9.0][FIX]account_analytic_parent. Improve tree view of chart of analytic accounts

### DIFF
--- a/account_analytic_parent/views/account_analytic_account_view.xml
+++ b/account_analytic_parent/views/account_analytic_account_view.xml
@@ -12,5 +12,48 @@
                 </field>
             </field>
         </record>
+
+        <record id="view_account_analytic_account_report" model="ir.ui.view">
+            <field name="name">account.analytic.account.report</field>
+            <field name="model">account.analytic.account</field>
+            <field name="field_parent">child_ids</field>
+            <field name="arch" type="xml">
+                <tree string="Analytic Accounts">
+                    <field name="display_name"/>
+                    <field name="code"/>
+                    <field name="partner_id"/>
+                    <field name="account_type" invisible="1"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
+                    <field name="debit"/>
+                    <field name="credit"/>
+                    <field name="balance"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="action_analytic_account_report"
+                model="ir.actions.act_window">
+            <field name="name">Analytic Accounts</field>
+            <field name="res_model">account.analytic.account</field>
+            <field name="view_type">tree</field>
+            <field name="view_mode">tree,form</field>
+            <field name="search_view_id"
+                   ref="analytic.view_account_analytic_account_search"/>
+            <field name="context">{'search_default_active':1}</field>
+            <field name="view_id" ref="view_account_analytic_account_report"/>
+            <field name="domain">[('parent_id','=',False)]</field>
+            <field name="help" type="html">
+              <p class="oe_view_nocontent_create">
+                Click to add an analytic account.
+              </p>
+            </field>
+        </record>
+
+        <menuitem name="Analytic Accounts"
+                  action="action_analytic_account_report"
+                  id="menu_action_analytic_account_report"
+                  parent="account.account_reports_business_intelligence_menu"
+                  sequence="30"/>
+
     </data>
 </odoo>

--- a/account_analytic_parent/views/account_analytic_account_view.xml
+++ b/account_analytic_parent/views/account_analytic_account_view.xml
@@ -16,9 +16,10 @@
         <record id="view_account_analytic_account_report" model="ir.ui.view">
             <field name="name">account.analytic.account.report</field>
             <field name="model">account.analytic.account</field>
+            <field name="groups_id" eval="[(4, ref('analytic.group_analytic_accounting'))]"/>
             <field name="field_parent">child_ids</field>
             <field name="arch" type="xml">
-                <tree string="Analytic Accounts">
+                <tree string="Analytic Accounts" groups="analytic.group_analytic_accounting">
                     <field name="display_name"/>
                     <field name="code"/>
                     <field name="partner_id"/>
@@ -51,6 +52,7 @@
 
         <menuitem name="Analytic Accounts"
                   action="action_analytic_account_report"
+                  groups="analytic.group_analytic_accounting"
                   id="menu_action_analytic_account_report"
                   parent="account.account_reports_business_intelligence_menu"
                   sequence="30"/>


### PR DESCRIPTION
Analytic Analytic Parent Improvement
============================

This PR modifies the chart of analytic accounts list view to reflect the hierarchy as it was done in previous versions of odoo:

![image](https://cloud.githubusercontent.com/assets/19620251/25478461/6ed3645e-2b41-11e7-8974-54b3da361d81.png)

There's an opened issue here: https://github.com/OCA/account-analytic/issues/65
