### PR TITLE
[IMP] account_analytic_parent: add tree view to adviser wizard

### DIFF
--- a/account_analytic_parent/__init__.py
+++ b/account_analytic_parent/__init__.py
@@ -6,3 +6,4 @@
 # Copyright 2017 Serpent Consulting Services Pvt. Ltd.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from . import models
+from . import wizard

--- a/account_analytic_parent/tests/test_account_analytic_account.py
+++ b/account_analytic_parent/tests/test_account_analytic_account.py
@@ -71,3 +71,12 @@ class TestAccountAnalyticRecursion(TransactionCase):
                          'Analytic account in the debit side')
         self.assertEqual(self.analytic_parent2.credit, 50, 'Wrong amount')
         self.assertEqual(self.analytic_parent2.balance, 50, 'Wrong amount')
+
+    def test_wizard(self):
+        self.wizard = self.env['account.analytic.chart'].create({
+            'from_date': '2017-01-01',
+            'to_date': '2017-12-31',
+        })
+        result = self.wizard.analytic_account_chart_open_window()
+        self.assertTrue('2017-01-01' in result['context'])
+        self.assertTrue('2017-12-31' in result['context'])

--- a/account_analytic_parent/views/account_analytic_account_view.xml
+++ b/account_analytic_parent/views/account_analytic_account_view.xml
@@ -50,12 +50,5 @@
             </field>
         </record>
 
-        <menuitem name="Analytic Accounts"
-                  action="action_analytic_account_report"
-                  groups="analytic.group_analytic_accounting"
-                  id="menu_action_analytic_account_report"
-                  parent="account.account_reports_business_intelligence_menu"
-                  sequence="30"/>
-
     </data>
 </odoo>

--- a/account_analytic_parent/wizard/__init__.py
+++ b/account_analytic_parent/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import account_analytic_wizard

--- a/account_analytic_parent/wizard/account_analytic_wizard.py
+++ b/account_analytic_parent/wizard/account_analytic_wizard.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Vicent Cubells
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, models
+
+
+class AccountAnalyticChart(models.TransientModel):
+    _inherit = 'account.analytic.chart'
+
+    @api.multi
+    def analytic_account_chart_open_window(self):
+        res = super(AccountAnalyticChart,
+                    self).analytic_account_chart_open_window()
+        ctx = res['context']
+        action = self.env['ir.actions.act_window'].for_xml_id(
+            'account_analytic_parent', 'action_analytic_account_report')
+        res = dict(res.items() + action.items())
+        res['context'] = ctx
+        return res


### PR DESCRIPTION
This improve tree view in analytic account wizard for advisers.

The tree view now is like this:

![6ed3645e-2b41-11e7-8974-54b3da361d81](https://cloud.githubusercontent.com/assets/4386443/25988770/98fd1eb4-36f9-11e7-9350-417dfc1ad52d.png)

cc @Tecnativa @jbeficent
