### PR TITLE
[IMP] Use new api to extend selection

### DIFF
--- a/account_analytic_required/models/account.py
+++ b/account_analytic_required/models/account.py
@@ -10,16 +10,11 @@ from odoo.tools import float_is_zero
 class AccountAccountType(models.Model):
     _inherit = "account.account.type"
 
-    @api.model
-    def _get_policies(self):
-        """This is the method to be inherited for adding policies"""
-        return [('optional', 'Optional'),
-                ('always', 'Always'),
-                ('never', 'Never')]
-
     analytic_policy = fields.Selection(
-        _get_policies,
-        'Policy for analytic account',
+        selection=[('optional', 'Optional'),
+                   ('always', 'Always'),
+                   ('never', 'Never')],
+        string='Policy for analytic account',
         required=True,
         default='optional',
         help="Set the policy for analytic accounts : if you select "


### PR DESCRIPTION
With new API it's not necessary this method because we can use selection_add to extend field. Even more, a selection method is incompatible with selection_add.

cc @Tecnativa