### PR TITLE
[FIX] incorrect dependencies

### DIFF
--- a/procurement_analytic/__openerp__.py
+++ b/procurement_analytic/__openerp__.py
@@ -11,7 +11,10 @@
     'author': "Tecnativa, "
               "Odoo Community Association (OCA)",
     'website': 'http://www.tecnativa.com',
-    'depends': ['procurement'],
+    'depends': [
+        'procurement',
+        'analytic',
+    ],
     'data': [
         'views/procurement_analytic.xml',
     ],

--- a/procurement_analytic/views/procurement_analytic.xml
+++ b/procurement_analytic/views/procurement_analytic.xml
@@ -10,7 +10,7 @@
     <field name="inherit_id" ref="procurement.procurement_form_view"/>
     <field name="arch" type="xml">
         <field name="group_id" position="after">
-            <field name="account_analytic_id" groups="purchase.group_analytic_accounting"/>
+            <field name="account_analytic_id" groups="analytic.group_analytic_accounting"/>
         </field>
     </field>
 </record>


### PR DESCRIPTION
Correct dependencies are needed in order to be able to read analytic_account_id field in procurement order.