### PR TITLE
[10.0] improve and extend product_analytic

### DIFF
--- a/product_analytic/__manifest__.py
+++ b/product_analytic/__manifest__.py
@@ -16,5 +16,6 @@
     'website': 'http://www.akretion.com',
     'depends': ['account'],
     'data': ['views/product_view.xml'],
+    'demo': ['demo/product_demo.xml'],
     'installable': True,
 }

--- a/product_analytic/demo/product_demo.xml
+++ b/product_analytic/demo/product_demo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<odoo noupdate="1">
+
+
+<record id="product.service_order_01" model="product.product">
+    <field name="income_analytic_account_id" ref="analytic.analytic_our_super_product"/>
+    <field name="expense_analytic_account_id" ref="analytic.analytic_our_super_product"/>
+</record>
+
+<record id="product.service_cost_01" model="product.product">
+    <field name="income_analytic_account_id" ref="analytic.analytic_integration_c2c"/>
+    <field name="expense_analytic_account_id" ref="analytic.analytic_agrolait"/>
+</record>
+
+<record id="product.product_delivery_01" model="product.product">
+    <field name="income_analytic_account_id" ref="analytic.analytic_our_super_product"/>
+    <field name="expense_analytic_account_id" ref="analytic.analytic_our_super_product"/>
+</record>
+
+<record id="product.product_product_17" model="product.product">
+    <field name="income_analytic_account_id" ref="analytic.analytic_seagate_p2"/>
+    <field name="expense_analytic_account_id" ref="analytic.analytic_seagate_p2"/>
+</record>
+
+
+</odoo>

--- a/product_analytic/models/account_invoice.py
+++ b/product_analytic/models/account_invoice.py
@@ -6,6 +6,13 @@
 
 from odoo import api, models
 
+INV_TYPE_MAP = {
+    'out_invoice': 'income',
+    'out_refund': 'income',
+    'in_invoice': 'expense',
+    'in_refund': 'expense',
+}
+
 
 class AccountInvoiceLine(models.Model):
     _inherit = 'account.invoice.line'
@@ -13,32 +20,23 @@ class AccountInvoiceLine(models.Model):
     @api.onchange('product_id')
     def _onchange_product_id(self):
         res = super(AccountInvoiceLine, self)._onchange_product_id()
-        type = self.invoice_id.type
-        product = self.product_id
-        if product:
-            if type in ('out_invoice', 'out_refund'):
-                self.account_analytic_id =\
-                    product.income_analytic_account_id.id or\
-                    product.categ_id.income_analytic_account_id.id
-            else:
-                self.account_analytic_id =\
-                    product.expense_analytic_account_id.id or\
-                    product.categ_id.expense_analytic_account_id.id
+        inv_type = self.invoice_id.type
+        if self.product_id:
+            ana_accounts = self.product_id.product_tmpl_id.\
+                _get_product_analytic_accounts()
+            ana_account = ana_accounts[INV_TYPE_MAP[inv_type]]
+            self.account_analytic_id = ana_account.id
         return res
 
     @api.model
     def create(self, vals):
-        type = self.env.context.get('inv_type', 'out_invoice')
-        if vals.get('product_id') and type and \
+        inv_type = self.env.context.get('inv_type', 'out_invoice')
+        if vals.get('product_id') and inv_type and \
                 not vals.get('account_analytic_id'):
             product = self.env['product.product'].browse(
                 vals.get('product_id'))
-            if type in ('out_invoice', 'out_refund'):
-                analytic_id = product.income_analytic_account_id.id or\
-                    product.categ_id.income_analytic_account_id.id
-            else:
-                analytic_id = product.expense_analytic_account_id.id or\
-                    product.categ_id.expense_analytic_account_id.id
-            if analytic_id:
-                vals['account_analytic_id'] = analytic_id
+            ana_accounts = product.product_tmpl_id.\
+                _get_product_analytic_accounts()
+            ana_account = ana_accounts[INV_TYPE_MAP[inv_type]]
+            vals['account_analytic_id'] = ana_account.id
         return super(AccountInvoiceLine, self).create(vals)

--- a/product_analytic/models/product.py
+++ b/product_analytic/models/product.py
@@ -4,7 +4,7 @@
 # Copyright 2017 Tecnativa - Luis Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductTemplate(models.Model):
@@ -16,6 +16,16 @@ class ProductTemplate(models.Model):
     expense_analytic_account_id = fields.Many2one(
         'account.analytic.account', string='Expense Analytic Account',
         company_dependent=True)
+
+    @api.multi
+    def _get_product_analytic_accounts(self):
+        self.ensure_one()
+        return {
+            'income': self.income_analytic_account_id or
+            self.categ_id.income_analytic_account_id,
+            'expense': self.expense_analytic_account_id or
+            self.categ_id.expense_analytic_account_id
+        }
 
 
 class ProductCategory(models.Model):

--- a/product_analytic_pos/README.rst
+++ b/product_analytic_pos/README.rst
@@ -1,0 +1,55 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+====================
+Product Analytic POS
+====================
+
+This module is a glue module between the *product_analytic* and
+*point_of_sale* modules. When you close a point of sale session, the analytic
+accounts configured on the products or the product categories will be used
+in the sale journal entry.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/87/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/analytic-account/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/product_analytic_pos/__init__.py
+++ b/product_analytic_pos/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/product_analytic_pos/__manifest__.py
+++ b/product_analytic_pos/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Akretion (http://www.akretion.com/) - Alexis de Lattre
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Product Analytic POS',
+    'version': '10.0.1.0.0',
+    'category': 'Point Of Sale',
+    'license': 'AGPL-3',
+    'summary': 'Glue module between product_analytic and point_of_sale',
+    'author': 'Akretion, Odoo Community Association (OCA)',
+    'website': 'http://www.akretion.com',
+    'depends': ['product_analytic', 'point_of_sale'],
+    'auto_install': True,
+    'installable': True,
+}

--- a/product_analytic_pos/models/__init__.py
+++ b/product_analytic_pos/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import pos_order

--- a/product_analytic_pos/models/pos_order.py
+++ b/product_analytic_pos/models/pos_order.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Akretion (http://www.akretion.com/) - Alexis de Lattre
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class PosOrder(models.Model):
+    _inherit = 'pos.order'
+
+    def _prepare_analytic_account(self, line):
+        ana_account_id = super(PosOrder, self)._prepare_analytic_account(line)
+        ana_accounts = line.product_id.product_tmpl_id.\
+            _get_product_analytic_accounts()
+        ana_account_id = ana_accounts['income'].id
+        return ana_account_id

--- a/product_analytic_purchase/README.rst
+++ b/product_analytic_purchase/README.rst
@@ -1,0 +1,58 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+Product Analytic Purchase
+=========================
+
+This module is a glue module between the *product_analytic* and
+*purchase* modules.
+
+Usage
+=====
+
+When you create a purchase order line with a product that has an
+**expense analytic account** (or whose internal category has an
+**expense analytic account**), it will be automatically set on the
+purchase order line.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/87/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/analytic-account/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/product_analytic_purchase/__init__.py
+++ b/product_analytic_purchase/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/product_analytic_purchase/__manifest__.py
+++ b/product_analytic_purchase/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Akretion (http://www.akretion.com/) - Alexis de Lattre
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Product Analytic Purchase',
+    'version': '10.0.1.0.0',
+    'category': 'Purchases',
+    'license': 'AGPL-3',
+    'summary': 'Glue module between purchase and product_analytic',
+    'author': 'Akretion, Odoo Community Association (OCA)',
+    'website': 'http://www.akretion.com',
+    'depends': ['purchase', 'product_analytic'],
+    'auto_install': True,
+    'installable': True,
+}

--- a/product_analytic_purchase/models/__init__.py
+++ b/product_analytic_purchase/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import purchase_order_line

--- a/product_analytic_purchase/models/purchase_order_line.py
+++ b/product_analytic_purchase/models/purchase_order_line.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Akretion (http://www.akretion.com/) - Alexis de Lattre
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    @api.onchange('product_id')
+    def onchange_product_id(self):
+        res = super(PurchaseOrderLine, self).onchange_product_id()
+        if self.product_id:
+            ana_accounts = self.product_id.product_tmpl_id.\
+                _get_product_analytic_accounts()
+            ana_account = ana_accounts['expense']
+            self.account_analytic_id = ana_account.id
+        return res
+
+    @api.model
+    def create(self, vals):
+        if vals.get('product_id') and not vals.get('account_analytic_id'):
+            product = self.env['product.product'].browse(
+                vals.get('product_id'))
+            ana_accounts = product.product_tmpl_id.\
+                _get_product_analytic_accounts()
+            ana_account = ana_accounts['expense']
+            vals['account_analytic_id'] = ana_account.id
+        return super(PurchaseOrderLine, self).create(vals)

--- a/product_analytic_purchase/tests/__init__.py
+++ b/product_analytic_purchase/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_purchase

--- a/product_analytic_purchase/tests/test_purchase.py
+++ b/product_analytic_purchase/tests/test_purchase.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# © 2015 Antiun Ingenieria - Javier Iniesta
+# © 2017 Tecnativa - Luis Martínez
+# © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestPurchaseOrderLine(TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseOrderLine, self).setUp()
+        self.product1 = self.env.ref('product.product_product_3')
+        self.product2 = self.env.ref('product.service_order_01')
+        self.assertTrue(self.product2.expense_analytic_account_id)
+        self.po = self.env['purchase.order'].create({
+            'partner_id': self.env.ref('base.res_partner_1').id,
+            'order_line': [
+                (0, 0, {
+                    'product_id': self.product1.id,
+                    'name': self.product1.name,
+                    'date_planned': '2017-07-17 12:42:12',
+                    'product_qty': 12,
+                    'product_uom': self.product1.uom_id.id,
+                    'price_unit': 42,
+                    })]
+            })
+        self.po_line1 = self.po.order_line[0]
+
+    def test_onchange_product_id(self):
+        self.po_line1.product_id = self.product2.id
+        self.po_line1.onchange_product_id()
+        self.assertEqual(
+            self.po_line1.account_analytic_id.id,
+            self.product2.expense_analytic_account_id.id)
+
+    def test_create(self):
+        pol_vals = {
+            'product_id': self.product2.id,
+            'name': self.product2.name,
+            'date_planned': '2017-07-17 12:42:12',
+            'product_qty': 42,
+            'product_uom': self.product2.uom_id.id,
+            'price_unit': 42,
+            'order_id': self.po.id
+            }
+        po_line2 = self.env['purchase.order.line'].create(pol_vals)
+        self.assertEqual(
+            po_line2.account_analytic_id.id,
+            self.product2.expense_analytic_account_id.id)


### PR DESCRIPTION
product_analytic:
- add method _get_product_analytic_accounts() similar to the one _get_product_accounts() of the account module
- product_analytic: add demo data

Add modules product_analytic_pos and product_analytic_purchase

Note that I had to develop "product_analytic_purchase" because, when you create an invoice from a PO, the product_id_change of invoice lines is not played (it is a special onchange purchase_order_change() on account.invoice).