### PR TITLE
[IMP][10.0]Procurement Analytic add views

### DIFF
--- a/procurement_analytic/README.rst
+++ b/procurement_analytic/README.rst
@@ -35,6 +35,7 @@ Contributors
 * Carlos Dauden <carlos.dauden@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Vicent Cubells <vicent.cubells@tecnativa.com>
+* Aaron Henriquez <ahenriquez@eficent.com>
 
 Maintainer
 ----------

--- a/procurement_analytic/__manifest__.py
+++ b/procurement_analytic/__manifest__.py
@@ -6,7 +6,7 @@
 {
     'name': 'Procurement Analytic',
     'summary': 'This module adds analytic account to procurements',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Analytic',
     'license': 'AGPL-3',
     'author': "Tecnativa, "
@@ -17,6 +17,7 @@
         'analytic',
     ],
     'data': [
+        'views/account_analytic_account_view.xml',
         'views/procurement_analytic.xml',
     ],
     'installable': True,

--- a/procurement_analytic/models/__init__.py
+++ b/procurement_analytic/models/__init__.py
@@ -2,4 +2,5 @@
 # Copyright 2016 Carlos Dauden <carlos.dauden@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import account_analytic_account
 from . import procurement

--- a/procurement_analytic/models/account_analytic_account.py
+++ b/procurement_analytic/models/account_analytic_account.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Carlos Dauden <carlos.dauden@tecnativa.com>
+# Copyright 2017 Vicent Cubells <vicent.cubells@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = "account.analytic.account"
+
+    procurement_ids = fields.One2many(
+        comodel_name='procurement.order',
+        inverse_name='account_analytic_id',
+        string='Procurement Orders',
+        copy=False)

--- a/procurement_analytic/views/account_analytic_account_view.xml
+++ b/procurement_analytic/views/account_analytic_account_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record model="ir.actions.act_window" id="act_analytic_account_2_procurement_order">
+            <field name="name">Procurement Orders</field>
+            <field name="res_model">procurement.order</field>
+            <field name="src_model">account.analytic.account</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_type">form</field>
+            <field name="view_id" ref="procurement_tree_view"/>
+            <field name="context">{'default_product_id': active_id, 'search_default_product_id': active_id}</field>
+
+        </record>
+
+        <record id="view_account_analytic_account_form_procurement_analytic" model="ir.ui.view">
+            <field name="name">account.analytic.account.form.procurement</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="analytic.view_account_analytic_account_form"/>
+            <field name="arch" type="xml">
+                <xpath expr='//div[@name="button_box"]' position='inside'>
+                    <button string="Procurement Orders"
+                            name="%(act_analytic_account_2_procurement_order)d"
+                            class="oe_stat_button"
+                            type="action"
+                            icon="fa-truck"
+                            context="{'default_analytic_account_id': active_id,'search_default_analytic_account_id': [active_id]}"/>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/procurement_analytic/views/account_analytic_account_view.xml
+++ b/procurement_analytic/views/account_analytic_account_view.xml
@@ -7,7 +7,7 @@
             <field name="src_model">account.analytic.account</field>
             <field name="view_mode">tree,form</field>
             <field name="view_type">form</field>
-            <field name="view_id" ref="procurement_tree_view"/>
+            <field name="view_id" ref="procurement.procurement_tree_view"/>
             <field name="context">{'default_product_id': active_id, 'search_default_product_id': active_id}</field>
 
         </record>

--- a/procurement_analytic/views/procurement_analytic.xml
+++ b/procurement_analytic/views/procurement_analytic.xml
@@ -15,4 +15,28 @@
         </field>
     </record>
 
+    <record id="procurement_form_view" model="ir.ui.view">
+         <field name="name">procurement.order.form</field>
+         <field name="model">procurement.order</field>
+         <field name="inherit_id" ref="procurement.procurement_form_view"/>
+         <field name="arch" type="xml">
+             <xpath expr="//group[@name='scheduling']" position="before">
+                 <group>
+                     <field name="account_analytic_id"/>
+                 </group>
+             </xpath>
+         </field>
+     </record>
+
+     <record id="view_procurement_filter" model="ir.ui.view">
+         <field name="name">procurement.order.select</field>
+         <field name="model">procurement.order</field>
+         <field name="inherit_id" ref="procurement.view_procurement_filter"/>
+         <field name="arch" type="xml">
+             <xpath expr='//field[@name="origin"]' position="after">
+                 <field name="account_analytic_id"/>
+             </xpath>
+         </field>
+     </record>
+    
 </odoo>


### PR DESCRIPTION
Added some extra features proposed here https://github.com/OCA/account-analytic/pull/120#issuecomment-316624123

- Added tree view and search view in procurements
- Added a button in the analytic accounts to see the procurements associated. This is useful for analyzing the procurements from a single analytic account