### PR TITLE
[9.0][IMP] account_analytic_parent: OpenUpgrade migration script

### DIFF
--- a/account_analytic_parent/migrations/9.0.1.0.0/pre-migration.py
+++ b/account_analytic_parent/migrations/9.0.1.0.0/pre-migration.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(cr, version):
+    """Restores visibility of accounts of type='view'. They are not exactly
+    the same as parent accounts, but both values are very tighted"""
+    openupgrade.logged_query(
+        cr,
+        """UPDATE account_analytic_account SET account_type='normal'
+        WHERE %s = 'view' AND %s NOT IN ('cancelled', 'close')
+        """ % (
+            openupgrade.get_legacy_name('type'),
+            openupgrade.get_legacy_name('state'),
+        )
+    )


### PR DESCRIPTION
For restoring the visibility of analytic accounts of type='view', which are very tighted with analytic accounts that are parents of another account.

cc @Tecnativa