### PR TITLE
[FIX][10.0]Pass the analytic account from the procurement to the move

### DIFF
--- a/stock_analytic/__manifest__.py
+++ b/stock_analytic/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Stock Analytic",
     "summary": "Adds an analytic account in stock move",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "Julius Network Solutions,"
               "ClearCorp, OpenSynergy Indonesia,"
               "Odoo Community Association (OCA)",
@@ -16,6 +16,7 @@
     "license": "AGPL-3",
     "depends": [
         "stock_account",
+        "procurement_analytic",
         "analytic",
     ],
     "data": [

--- a/stock_analytic/models/__init__.py
+++ b/stock_analytic/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import procurement
 from . import stock

--- a/stock_analytic/models/procurement.py
+++ b/stock_analytic/models/procurement.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013 Julius Network Solutions
+# Copyright 2015 Clear Corp
+# Copyright 2016 OpenSynergy Indonesia
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class Procurement(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def _get_stock_move_values(self):
+        res = super(Procurement, self)._get_stock_move_values()
+        analytic = self.account_analytic_id
+        if analytic:
+            res['analytic_account_id'] = analytic.id
+        return res

--- a/stock_analytic/tests/__init__.py
+++ b/stock_analytic/tests/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_stock_picking
+from . import test_procurement

--- a/stock_analytic/tests/test_procurement.py
+++ b/stock_analytic/tests/test_procurement.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013 Julius Network Solutions
+# Copyright 2015 Clear Corp
+# Copyright 2016 OpenSynergy Indonesia
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProcurement(TransactionCase):
+
+    def setUp(self):
+        super(TestProcurement, self).setUp()
+        self.stock_move_model = self.env['stock.move']
+        self.procurement_order_model = self.env['procurement.order']
+        self.procurement_rule_model = self.env['procurement.rule']
+        self.warehouse_id = self.env.ref('stock.warehouse0')
+        # Products
+        self.product1 = self.env.ref('product.product_product_9')
+
+        # Picking Type
+        self.wh = self.env.ref('stock.warehouse0')
+        self.stock_loc = self.env.ref('stock.stock_location_stock').id
+        self.l2 = self.env['stock.location'].create({
+            'location_id': self.stock_loc,
+            'name': 'Shelf 1',
+            'usage': 'internal'
+        })
+        self.picking_type = self.env.ref('stock.picking_type_internal')
+        self.AA = self.env.ref('analytic.analytic_agrolait')
+        self.rule = self._create_procurement_rule()
+        self.procurement_order = self._create_procurement_order()
+
+    def _create_procurement_rule(self):
+        rule = self.procurement_rule_model. \
+            create({'name': 'Procurement rule',
+                    'action': 'move',
+                    'location_id': self.stock_loc,
+                    'location_src_id': self.l2.id,
+                    'picking_type_id': self.picking_type.id,
+                    })
+        return rule
+
+    def _create_procurement_order(self):
+        # On change for warehouse_id
+        new_line = self.procurement_order_model.new()
+        new_line.warehouse_id = self.warehouse_id
+        new_line.onchange_warehouse_id()
+        location_id = new_line.location_id
+        # On change for product_id
+        new_line = self.procurement_order_model.new()
+        new_line.product_id = self.product1.id
+        new_line.onchange_product_id()
+        product_uom = new_line.product_uom
+        procurement = self.procurement_order_model. \
+            create({'product_id': self.product1.id,
+                    'product_uom': product_uom.id,
+                    'product_qty': '10',
+                    'name': 'Procurement Order',
+                    'warehouse_id': self.warehouse_id.id,
+                    'rule_id': self.rule.id,
+                    'account_analytic_id': self.AA.id,
+                    'location_id': location_id.id,
+                    })
+        procurement.run()
+        procurement.check()
+        return procurement
+
+    def test_outgoing_picking_with_analytic(self):
+        move = self.stock_move_model.search(
+            [('procurement_id', '=', self.procurement_order.id)])
+        self.assertEqual(move.analytic_account_id.id, self.AA.id)


### PR DESCRIPTION
It solves issue: https://github.com/OCA/account-analytic/issues/137

Current behaviour: When a procurement has an analytic account ii will not pass the analytic information to the stock move. It has to be set manually.

Expected behaviour: The analytic account is passed from the procurement to the stock move.

As the stock module depends on procurement module, the stock analytic module should depend on procurement_analytic module and pass the information from the procurement to the stock move.