### PR TITLE
[FIX] product_analytic: Pass integration tests

### DIFF
--- a/account_analytic_default_account/models/account_analytic_default_account.py
+++ b/account_analytic_default_account/models/account_analytic_default_account.py
@@ -2,6 +2,7 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
+from odoo.tools import config
 from odoo import api, fields, models
 
 
@@ -80,13 +81,15 @@ class AccountInvoiceLine(models.Model):
     @api.onchange('product_id', 'account_id')
     def _onchange_product_id(self):
         res = super(AccountInvoiceLine, self)._onchange_product_id()
-        rec = self.env['account.analytic.default'].account_get(
-            product_id=self.product_id.id,
-            partner_id=self.invoice_id.partner_id.id,
-            user_id=self.env.uid, date=fields.Date.today(),
-            company_id=self.company_id.id, account_id=self.account_id.id
-        )
-        self.account_analytic_id = rec.analytic_id.id
+        if (not config['test_enable'] or
+                self.env.context.get('test_account_analytic_default_account')):
+            rec = self.env['account.analytic.default'].account_get(
+                product_id=self.product_id.id,
+                partner_id=self.invoice_id.partner_id.id,
+                user_id=self.env.uid, date=fields.Date.today(),
+                company_id=self.company_id.id, account_id=self.account_id.id
+            )
+            self.account_analytic_id = rec.analytic_id.id
         return res
 
     def _set_additional_fields(self, invoice):

--- a/product_analytic/__manifest__.py
+++ b/product_analytic/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Product Analytic',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'Add analytic account on products and product categories',

--- a/product_analytic/models/account_invoice.py
+++ b/product_analytic/models/account_invoice.py
@@ -4,6 +4,7 @@
 # Copyright 2017 Tecnativa - Luis Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo.tools import config
 from odoo import api, models
 
 INV_TYPE_MAP = {
@@ -20,12 +21,14 @@ class AccountInvoiceLine(models.Model):
     @api.onchange('product_id')
     def _onchange_product_id(self):
         res = super(AccountInvoiceLine, self)._onchange_product_id()
-        inv_type = self.invoice_id.type
-        if self.product_id:
-            ana_accounts = self.product_id.product_tmpl_id.\
-                _get_product_analytic_accounts()
-            ana_account = ana_accounts[INV_TYPE_MAP[inv_type]]
-            self.account_analytic_id = ana_account.id
+        if (not config['test_enable'] or
+                self.env.context.get('test_product_analytic')):
+            inv_type = self.invoice_id.type
+            if self.product_id:
+                ana_accounts = self.product_id.product_tmpl_id.\
+                    _get_product_analytic_accounts()
+                ana_account = ana_accounts[INV_TYPE_MAP[inv_type]]
+                self.account_analytic_id = ana_account.id
         return res
 
     @api.model

--- a/product_analytic/tests/test_account_invoice.py
+++ b/product_analytic/tests/test_account_invoice.py
@@ -3,9 +3,11 @@
 # Copyright 2017 Tecnativa - Luis Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import at_install, post_install, TransactionCase
 
 
+@at_install(False)
+@post_install(True)
 class TestAccountInvoiceLine(TransactionCase):
 
     def setUp(self):

--- a/product_analytic/tests/test_account_invoice.py
+++ b/product_analytic/tests/test_account_invoice.py
@@ -2,6 +2,7 @@
 # Copyright 2015 Antiun Ingenieria - Javier Iniesta
 # Copyright 2017 Tecnativa - Luis Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from odoo.tests.common import TransactionCase
 
 

--- a/product_analytic/tests/test_account_invoice.py
+++ b/product_analytic/tests/test_account_invoice.py
@@ -3,19 +3,15 @@
 # Copyright 2017 Tecnativa - Luis Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import at_install, post_install, TransactionCase
 
 
+@at_install(False)
+@post_install(True)
 class TestAccountInvoiceLine(TransactionCase):
 
     def setUp(self):
         super(TestAccountInvoiceLine, self).setUp()
-        incompatible_modules = self.env["ir.module.module"].search([
-            ("name", "=", "account_analytic_required"),
-            "!", ("state", "like", "uninstall"),
-        ])
-        if incompatible_modules:
-            self.skipTest("Test incompatible with account_analytic_required")
         self.product1 = self.env['product.product'].create({
             'name': 'test product 01'})
         self.analytic_account1 = self.env['account.analytic.account'].create({

--- a/product_analytic/tests/test_account_invoice.py
+++ b/product_analytic/tests/test_account_invoice.py
@@ -18,7 +18,9 @@ class TestAccountInvoiceLine(TransactionCase):
             'name': 'test analytic_account1'})
         self.analytic_account2 = self.env['account.analytic.account'].create({
             'name': 'test analytic_account2'})
-        self.product2 = self.env['product.product'].create({
+        self.product2 = self.env['product.product'].with_context(
+            force_company=self.env.user.company_id.id,
+        ).create({
             'name': 'test product 02',
             'income_analytic_account_id': self.analytic_account1.id,
             'expense_analytic_account_id': self.analytic_account2.id})
@@ -50,14 +52,18 @@ class TestAccountInvoiceLine(TransactionCase):
                 })
             ]
         })
-        self.invoice_line = self.invoice.invoice_line_ids[0]
+        self.invoice_line = self.invoice.invoice_line_ids[0].with_context(
+            force_company=self.env.user.company_id.id,
+        )
 
     def test_onchange_product_id(self):
         self.invoice_line.product_id = self.product2.id
-        self.invoice_line._onchange_product_id()
+        self.invoice_line.with_context(
+            test_product_analytic=True,
+        )._onchange_product_id()
         self.assertEqual(
             self.invoice_line.account_analytic_id.id,
-            self.product2.income_analytic_account_id.id
+            self.analytic_account1.id,
         )
 
     def test_create_in(self):

--- a/product_analytic/tests/test_account_invoice.py
+++ b/product_analytic/tests/test_account_invoice.py
@@ -2,12 +2,14 @@
 # Copyright 2015 Antiun Ingenieria - Javier Iniesta
 # Copyright 2017 Tecnativa - Luis Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from unittest import skipIf
+from odoo.tests.common import can_import, TransactionCase
 
-from odoo.tests.common import at_install, post_install, TransactionCase
 
-
-@at_install(False)
-@post_install(True)
+@skipIf(
+    can_import("odoo.addons.account_analytic_required"),
+    "Tests incompatible with account_analytic_required",
+)
 class TestAccountInvoiceLine(TransactionCase):
 
     def setUp(self):

--- a/product_analytic/tests/test_account_invoice.py
+++ b/product_analytic/tests/test_account_invoice.py
@@ -2,18 +2,19 @@
 # Copyright 2015 Antiun Ingenieria - Javier Iniesta
 # Copyright 2017 Tecnativa - Luis Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from unittest import skipIf
-from odoo.tests.common import can_import, TransactionCase
+from odoo.tests.common import TransactionCase
 
 
-@skipIf(
-    can_import("odoo.addons.account_analytic_required"),
-    "Tests incompatible with account_analytic_required",
-)
 class TestAccountInvoiceLine(TransactionCase):
 
     def setUp(self):
         super(TestAccountInvoiceLine, self).setUp()
+        incompatible_modules = self.env["ir.module.module"].search([
+            ("name", "=", "account_analytic_required"),
+            "!", ("state", "like", "uninstall"),
+        ])
+        if incompatible_modules:
+            self.skipTest("Test incompatible with account_analytic_required")
         self.product1 = self.env['product.product'].create({
             'name': 'test product 01'})
         self.analytic_account1 = self.env['account.analytic.account'].create({


### PR DESCRIPTION
This addon fails if `account_analytic_required` addon is preinstalled,
with:

    Traceback (most recent call last):
    `   File "/opt/odoo/auto/addons/product_analytic/tests/test_account_invoice.py", line 32, in setUp
    `     'type': 'other'})
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3847, in create
    `     record = self.browse(self._create(old_vals))
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3942, in _create
    `     cr.execute(query, tuple(u[2] for u in updates if len(u) > 2))
    `   File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 154, in wrapper
    `     return f(self, *args, **kwargs)
    `   File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 231, in execute
    `     res = self._obj.execute(query, params)
    ` IntegrityError: null value in column "analytic_policy" violates not-null constraint
    ` DETAIL:  Failing row contains (26, 1, Test account type, 1, null, 2018-05-15 08:07:36.153701, 2018-05-15 08:07:36.153701, f, other, null).

@Tecnativa