### PR TITLE
ADD analytic_product_category module

### DIFF
--- a/analytic_product_category/README.rst
+++ b/analytic_product_category/README.rst
@@ -1,0 +1,59 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=============================================
+Base Analytic Product Category Categorization
+=============================================
+
+This module add Product Category (related with Product itself) on Analytic Entries.
+
+Usage
+=====
+
+As Product Category is related with Product, and Analytic Entries has Product,
+now you can filter and group by Product Category on Analytic Entries,
+on list and reporting view.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/87/11.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-analytic/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
+
+Contributors
+------------
+
+* Angel Moya <angel.moya@pesol.es>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/analytic_product_category/__init__.py
+++ b/analytic_product_category/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from .init_hook import pre_init_hook

--- a/analytic_product_category/__manifest__.py
+++ b/analytic_product_category/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2017 PESOL (http://pesol.es)
+#                Angel Moya (angel.moya@pesol.es)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+{
+    "name": "Base Analytic Product Category Categorization",
+    "summary": "Filter and Group Analytic Entries by Product Category",
+    "category": "Generic Modules/Accounting",
+    "version": "11.0.1.0.0",
+    "author": "PESOL, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/account-analytic",
+    "depends": ["account"],
+    "data": ["views/analytic.xml"],
+    'pre_init_hook': 'pre_init_hook',
+    "installable": True,
+}

--- a/analytic_product_category/init_hook.py
+++ b/analytic_product_category/init_hook.py
@@ -1,0 +1,45 @@
+# Copyright 2017 PESOL (http://pesol.es)
+#                Angel Moya (angel.moya@pesol.es)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    """
+    The objective of this hook is to speed up the installation
+    of the module on an existing Odoo instance.
+
+    Without this script, if a database has a few hundred thousand
+    analitic entries, which is not unlikely, the update will take
+    at least a few hours.
+    """
+    store_field_stored_product_category_id(cr)
+
+
+def store_field_stored_product_category_id(cr):
+
+    cr.execute("""SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name='account_analytic_line' AND
+    column_name='product_category_id'""")
+    if not cr.fetchone():
+        cr.execute(
+            """
+            ALTER TABLE account_analytic_line
+            ADD COLUMN product_category_id integer;
+            COMMENT ON COLUMN account_analytic_line.product_category_id
+            IS 'Product Category';
+            """)
+
+    logger.info('Computing field product_category_id on account.analytic.line')
+
+    cr.execute(
+        """
+        UPDATE account_analytic_line aal
+        SET product_category_id = pt.categ_id
+        FROM product_product pp
+            JOIN product_template pt ON pp.product_tmpl_id = pt.id
+        """
+    )

--- a/analytic_product_category/models/__init__.py
+++ b/analytic_product_category/models/__init__.py
@@ -1,0 +1,1 @@
+from . import analytic

--- a/analytic_product_category/models/analytic.py
+++ b/analytic_product_category/models/analytic.py
@@ -1,0 +1,15 @@
+# Copyright 2017 PESOL (http://pesol.es)
+#                Angel Moya (angel.moya@pesol.es)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class AnalyticLine(models.Model):
+    _inherit = "account.analytic.line"
+
+    product_category_id = fields.Many2one(
+        comodel_name='product.category',
+        string='Product Category',
+        related='product_id.categ_id',
+        store=True,
+        readonly=True)

--- a/analytic_product_category/views/analytic.xml
+++ b/analytic_product_category/views/analytic.xml
@@ -1,0 +1,28 @@
+<odoo>
+
+  <record id="view_account_analytic_line_product_category_form" model="ir.ui.view">
+    <field name="name">account.analytic.line.product.category.form</field>
+    <field name="model">account.analytic.line</field>
+    <field name="inherit_id" ref="account.view_account_analytic_line_form_inherit_account"/>
+    <field name="arch" type="xml">
+      <field name="product_id" position="after">
+        <field name="product_category_id"/>
+      </field>
+    </field>
+  </record>
+
+  <record id="view_account_analytic_line_product_category_filter" model="ir.ui.view">
+    <field name="name">account.analytic.line.product.category.select</field>
+    <field name="model">account.analytic.line</field>
+    <field name="inherit_id" ref="account.view_account_analytic_line_filter_inherit_account"/>
+    <field name="arch" type="xml">
+      <field name="product_id" position="after">
+        <field name="product_category_id"/>
+      </field>
+      <xpath expr="//filter[2]" position="after">
+        <filter string="Product Category" domain="[]" context="{'group_by':'product_category_id'}"/>
+      </xpath>
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
Base Analytic Product Category Categorization
=============================================

This module add Product Category (related with Product itself) on Analytic Entries.

Usage
=====

As Product Category is related with Product, and Analytic Entries has Product,
now you can filter and group by Product Category on Analytic Entries,
on list and reporting view.