### PR TITLE
[10.0][IMP] purchase_procurement_analytic: Take into account bare pro…

### DIFF
--- a/purchase_procurement_analytic/README.rst
+++ b/purchase_procurement_analytic/README.rst
@@ -53,6 +53,7 @@ Contributors
 * Carlos Dauden <carlos.dauden@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Vicent Cubells <vicent.cubells@tecnativa.com>
+* Denis Roussel <denis.roussel@acsone.eu>
 
 Maintainer
 ----------

--- a/purchase_procurement_analytic/__manifest__.py
+++ b/purchase_procurement_analytic/__manifest__.py
@@ -7,7 +7,7 @@
     'name': 'Purchase Procurement Analytic',
     'summary': 'This module sets analytic account in purchase order line from '
                'procurement analytic account',
-    'version': '10.0.1.0.2',
+    'version': '10.0.2.0.0',
     'category': 'Analytic',
     'license': 'AGPL-3',
     'author': "Tecnativa, "
@@ -16,6 +16,7 @@
     'depends': [
         'purchase',
         'procurement_analytic',
+        'stock_analytic',
     ],
     'installable': True,
 }

--- a/purchase_procurement_analytic/models/__init__.py
+++ b/purchase_procurement_analytic/models/__init__.py
@@ -3,4 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import procurement
+from . import purchase_order_line
 from . import stock

--- a/purchase_procurement_analytic/models/purchase_order_line.py
+++ b/purchase_procurement_analytic/models/purchase_order_line.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class PurchaseOrderLine(models.Model):
+
+    _inherit = 'purchase.order.line'
+
+    @api.multi
+    def _create_stock_moves(self, picking):
+        moves = super(PurchaseOrderLine, self)._create_stock_moves(
+            picking=picking)
+        for move in moves.filtered(lambda m: not m.analytic_account_id):
+            move.write({
+                'analytic_account_id':
+                    move.purchase_line_id.account_analytic_id.id
+            })
+        return moves

--- a/purchase_procurement_analytic/tests/test_purchase_procurement_analytic.py
+++ b/purchase_procurement_analytic/tests/test_purchase_procurement_analytic.py
@@ -97,3 +97,11 @@ class TestPurchaseProcurementAnalytic(common.SavepointCase):
             self.procurement_1.purchase_id,
             self.procurement_2.purchase_id,
         )
+
+    def test_purchase_from_procurement(self):
+        purchase_line = self.procurement_2.purchase_line_id
+        purchase_line.order_id.button_confirm()
+        self.assertEquals(
+            self.analytic_account,
+            purchase_line.move_ids.analytic_account_id,
+        )


### PR DESCRIPTION
…curement

If purchase orders were generated through bare procurement orders, generated moves do not
contain the analytic account set on procurement.