### PR TITLE
[10.0][FIX] purchase_procurement_analytic: Purchase grouping

### DIFF
--- a/purchase_procurement_analytic/__manifest__.py
+++ b/purchase_procurement_analytic/__manifest__.py
@@ -7,7 +7,7 @@
     'name': 'Purchase Procurement Analytic',
     'summary': 'This module sets analytic account in purchase order line from '
                'procurement analytic account',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'category': 'Analytic',
     'license': 'AGPL-3',
     'author': "Tecnativa, "

--- a/purchase_procurement_analytic/models/procurement.py
+++ b/purchase_procurement_analytic/models/procurement.py
@@ -18,7 +18,6 @@ class ProcurementOrder(models.Model):
     def _make_po_get_domain(self, partner):
         res = super(ProcurementOrder, self)._make_po_get_domain(
             partner=partner)
-        if self.account_analytic_id:
-            res += (('order_line.account_analytic_id',
-                     '=', self.account_analytic_id.id),)
+        res += (('order_line.account_analytic_id',
+                 '=', self.account_analytic_id.id),)
         return res

--- a/purchase_procurement_analytic/tests/test_purchase_procurement_analytic.py
+++ b/purchase_procurement_analytic/tests/test_purchase_procurement_analytic.py
@@ -79,3 +79,21 @@ class TestPurchaseProcurementAnalytic(common.SavepointCase):
             self.procurement_1.purchase_id,
             self.procurement_2.purchase_id,
         )
+
+    def test_procurement_to_purchase_no_analytic(self):
+        # Testing void analytic account on procurement run after the
+        # other one
+        # Run procurement
+        self.procurement_2.run()
+        self.procurement_1.run()
+        self.assertTrue(
+            self.procurement_2.purchase_id)
+        # Make sure that PO line have analytic account
+        self.assertEqual(
+            self.procurement_2.purchase_line_id.account_analytic_id.id,
+            self.analytic_account.id)
+        # Testing all procurements have filled in different purchases
+        self.assertNotEquals(
+            self.procurement_1.purchase_id,
+            self.procurement_2.purchase_id,
+        )


### PR DESCRIPTION
When procurements with no analytic account (e.g. Reordering rules) are run with
existing purchase orders (with analytic account defined), it adds purchase line
on purchase with order lines with analytic. It shouldn't.