### PR TITLE
[10.0][IMP]account_analytic_parent. Propagate active through hierarchy

### DIFF
--- a/account_analytic_parent/models/account_analytic_account.py
+++ b/account_analytic_parent/models/account_analytic_account.py
@@ -67,8 +67,8 @@ class AccountAnalyticAccount(models.Model):
             if (account.active and account.parent_id and not
                     account.parent_id.active):
                 raise UserError(
-                    _('Please activate first parent account')
-                    % self.parent_id.display_name)
+                    _('Please activate first parent account %s')
+                    % account.parent_id.display_name)
 
     @api.multi
     def archive_account(self):

--- a/account_analytic_parent/models/account_analytic_account.py
+++ b/account_analytic_parent/models/account_analytic_account.py
@@ -61,6 +61,16 @@ class AccountAnalyticAccount(models.Model):
         return res
 
     @api.multi
+    @api.constrains('active')
+    def check_parent_active(self):
+        for account in self:
+            if (account.active and account.parent_id and not
+                    account.parent_id.active):
+                raise UserError(
+                    _('Please activate first parent account')
+                    % self.parent_id.display_name)
+
+    @api.multi
     def archive_account(self):
         for account in self:
             account.active = False

--- a/account_analytic_parent/models/account_analytic_account.py
+++ b/account_analytic_parent/models/account_analytic_account.py
@@ -59,3 +59,14 @@ class AccountAnalyticAccount(models.Model):
                 current = current.parent_id
             res.append((account.id, name))
         return res
+
+    @api.multi
+    def archive_account(self):
+        for account in self:
+            account.active = False
+
+    @api.multi
+    def write(self, vals):
+        if 'active' in vals and not vals['active']:
+            self.mapped('child_ids').archive_account()
+        return super(AccountAnalyticAccount, self).write(vals)

--- a/account_analytic_parent/tests/test_account_analytic_account.py
+++ b/account_analytic_parent/tests/test_account_analytic_account.py
@@ -81,3 +81,9 @@ class TestAccountAnalyticRecursion(TransactionCase):
         result = self.wizard.analytic_account_chart_open_window()
         self.assertTrue('2017-01-01' in result['context'])
         self.assertTrue('2017-12-31' in result['context'])
+
+    def test_archive(self):
+        self.analytic_parent1.toggle_active()
+        self.assertEqual(self.analytic_son.active, False)
+        self.analytic_parent1.toggle_active()
+        self.assertEqual(self.analytic_son.active, False)

--- a/account_analytic_parent/tests/test_account_analytic_account.py
+++ b/account_analytic_parent/tests/test_account_analytic_account.py
@@ -87,3 +87,6 @@ class TestAccountAnalyticRecursion(TransactionCase):
         self.assertEqual(self.analytic_son.active, False)
         self.analytic_parent1.toggle_active()
         self.assertEqual(self.analytic_son.active, False)
+        self.analytic_parent1.toggle_active()
+        with self.assertRaises(ValidationError):
+            self.analytic_son.toggle_active()


### PR DESCRIPTION
If the parent analytic account is archived then all the children accounts should be archived. The same the other way around. 

When manual archiving the accounts it is common to miss some of the children causing confusion to see archived accounts appearing again.

Perhaps the parents should be also archived, but I am not sure of that...