### PR TITLE
[10.0][FIX] product_analytic_purchase: Only is executed if exist product

### DIFF
--- a/product_analytic_purchase/README.rst
+++ b/product_analytic_purchase/README.rst
@@ -41,6 +41,7 @@ Contributors
 ------------
 
 * Alexis de Lattre <alexis.delattre@akretion.com>
+* Isaac Gallart <igallart@puntsistemes.es>
 
 Maintainer
 ----------

--- a/product_analytic_purchase/__manifest__.py
+++ b/product_analytic_purchase/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Product Analytic Purchase',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Purchases',
     'license': 'AGPL-3',
     'summary': 'Glue module between purchase and product_analytic',

--- a/product_analytic_purchase/models/purchase_order_line.py
+++ b/product_analytic_purchase/models/purchase_order_line.py
@@ -11,7 +11,7 @@ class PurchaseOrderLine(models.Model):
     @api.onchange('product_id')
     def onchange_product_id(self):
         res = super(PurchaseOrderLine, self).onchange_product_id()
-        if self.product_id:
+        if self.product_id.product_tmpl_id:
             ana_accounts = self.product_id.product_tmpl_id.\
                 _get_product_analytic_accounts()
             ana_account = ana_accounts['expense']


### PR DESCRIPTION
If product is empty, _get_product_analytic_accounts from product_analytic module fails