### PR TITLE
[FIX] procurement_mto_analytic: added missing dependency

### DIFF
--- a/procurement_mto_analytic/__manifest__.py
+++ b/procurement_mto_analytic/__manifest__.py
@@ -13,6 +13,7 @@
     'website': 'https://github.com/OCA/account-analytic',
     'depends': [
         'sale_stock',
+        'stock_analytic',
         'purchase',
     ],
     'installable': True,


### PR DESCRIPTION
Tests earlier likely passed because the dependency is in the
same repository, and so the CI would install both modules for running
tests, thus making it seem like it should work.