### PR TITLE
[11.0][FIX] account_analytic_distribution travis warn

### DIFF
--- a/account_analytic_distribution/views/account_move_line_view.xml
+++ b/account_analytic_distribution/views/account_move_line_view.xml
@@ -15,17 +15,6 @@
         </field>
     </record>
 
-    <record id="view_move_form" model="ir.ui.view">
-        <field name="name">account.move.form</field>
-        <field name="model">account.move</field>
-        <field name="inherit_id" ref="account.view_move_form"/>
-        <field name="arch" type="xml">
-            <field name="analytic_account_id" position="before">
-                <field name="analytic_distribution_id" groups="analytic.group_analytic_accounting"/>
-            </field>
-        </field>
-    </record>
-
      <record id="view_move_line_tree" model="ir.ui.view">
         <field name="name">account.move.line.tree</field>
         <field name="model">account.move.line</field>


### PR DESCRIPTION
duplicate view definition in the files:
account_move_view.xml
account_move_line_view.xml

removed it from account_move_line_view.xml as the model used for the view is account.move
and account.move.line has already the view view_move_line_form for the field analytic_distribution_id