### PR TITLE
[FIX] corrects no type error

### DIFF
--- a/product_analytic/models/account_invoice.py
+++ b/product_analytic/models/account_invoice.py
@@ -20,7 +20,7 @@ class AccountInvoiceLine(models.Model):
     def _onchange_product_id(self):
         res = super()._onchange_product_id()
         inv_type = self.invoice_id.type
-        if self.product_id:
+        if self.product_id and inv_type:
             ana_accounts = self.product_id.product_tmpl_id.\
                 _get_product_analytic_accounts()
             ana_account = ana_accounts[INV_TYPE_MAP[inv_type]]


### PR DESCRIPTION
I have got following ValueError, when I create an invoice by using the module "contract".

`ana_account = ana_accounts[INV_TYPE_MAP[inv_type]]`
`ValueError: <class 'KeyError'>: "False" while evaluating`

Link to Modul contract:
https://github.com/OCA/contract/blob/91806ab1f8f50238b29cb7cd64e0580e11600206/contract/models/contract.py#L333

