### PR TITLE
[FIX] Do only change partner_id in onchange if parent_id is set

### DIFF
--- a/account_analytic_parent/models/account_analytic_account.py
+++ b/account_analytic_parent/models/account_analytic_account.py
@@ -103,7 +103,8 @@ class AccountAnalyticAccount(models.Model):
     @api.onchange('parent_id')
     def _onchange_parent_id(self):
         for account in self:
-            account.partner_id = account.parent_id.partner_id
+            if account.parent_id:
+                account.partner_id = account.parent_id.partner_id
 
     @api.depends('name', 'parent_id.complete_name')
     def _compute_complete_name(self):


### PR DESCRIPTION
Current behaviour without this small fix - if the account_analytic_parent module is installed - and you like to create a new analytic account by clicking on the smart button in the res.partner form - then it will open the list,form for a new analytic account - but partner_id is not filled - because the onchange did removed it.

The onchange should check if a parent_id is set - and only set partner_id if a parent_id is set !

Please merge this as soon as possible - its just a small fix