### PR TITLE
[12.0][FIX] stock_analytic: moves with different analytic accounts

### DIFF
--- a/stock_analytic/models/stock.py
+++ b/stock_analytic/models/stock.py
@@ -34,6 +34,12 @@ class StockMove(models.Model):
                 })
         return res
 
+    @api.model
+    def _prepare_merge_moves_distinct_fields(self):
+        fields = super()._prepare_merge_moves_distinct_fields()
+        fields.append('analytic_account_id')
+        return fields
+
 
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"


### PR DESCRIPTION
Moves with different analytic accounts should not be merged.

This PR just adds `analytic_account_id` to the list of distinctive fields.