### PR TITLE
[FIX] On Vendor invoice correct the analytic account

### DIFF
--- a/product_analytic/models/account_invoice.py
+++ b/product_analytic/models/account_invoice.py
@@ -29,7 +29,7 @@ class AccountInvoiceLine(models.Model):
 
     @api.model
     def create(self, vals):
-        inv_type = self.env.context.get('inv_type', 'out_invoice')
+        inv_type = self.env.context.get('type', 'out_invoice')
         if vals.get('product_id') and inv_type and \
                 not vals.get('account_analytic_id'):
             product = self.env['product.product'].browse(


### PR DESCRIPTION
On the Vendor invoices, when creating form a purchase order the analytic wasn't computed right.
It was always using the out_invoice account.

This corrects it.