### PR TITLE
[12.0][account_analytic_required] company_dependent analytic_policy

### DIFF
--- a/account_analytic_distribution_required/models/account.py
+++ b/account_analytic_distribution_required/models/account.py
@@ -9,7 +9,7 @@ from odoo import _, api, exceptions, fields, models
 class AccountAccountType(models.Model):
     _inherit = "account.account.type"
 
-    analytic_policy = fields.Selection(
+    property_analytic_policy = fields.Selection(
         selection_add=[
             ('always_plan', _('Always (analytic distribution)')),
             ('always_plan_or_account',

--- a/account_analytic_distribution_required/models/account.py
+++ b/account_analytic_distribution_required/models/account.py
@@ -11,9 +11,9 @@ class AccountAccountType(models.Model):
 
     property_analytic_policy = fields.Selection(
         selection_add=[
-            ('always_plan', _('Always (analytic distribution)')),
+            ('always_plan', 'Always (analytic distribution)'),
             ('always_plan_or_account',
-             _('Always (analytic account or distribution)'))
+             'Always (analytic account or distribution)')
         ],
     )
 

--- a/account_analytic_distribution_required/tests/test_account_analytic_plan_required.py
+++ b/account_analytic_distribution_required/tests/test_account_analytic_plan_required.py
@@ -87,7 +87,7 @@ class TestAccountAnalyticPlanRequired(SavepointCase):
 
     def test_always_no_analytic(self):
         self.account_type.write({
-            'analytic_policy': 'always',
+            'property_analytic_policy': 'always',
         })
         with self.assertRaises(ValidationError):
             self._create_move(with_analytic=False, with_analytic_plan=False)
@@ -97,20 +97,20 @@ class TestAccountAnalyticPlanRequired(SavepointCase):
     def test_always_no_analytic_0(self):
         # accept missing analytic account when debit=credit=0
         self.account_type.write({
-            'analytic_policy': 'always',
+            'property_analytic_policy': 'always',
         })
         self._create_move(with_analytic=False, with_analytic_plan=False,
                           amount=0)
 
     def test_always_with_analytic(self):
         self.account_type.write({
-            'analytic_policy': 'always',
+            'property_analytic_policy': 'always',
         })
         self._create_move(with_analytic=True, with_analytic_plan=False)
 
     def test_always_plan_no_analytic_plan(self):
         self.account_type.write({
-            'analytic_policy': 'always_plan',
+            'property_analytic_policy': 'always_plan',
         })
         with self.assertRaises(ValidationError):
             self._create_move(with_analytic=False, with_analytic_plan=False)
@@ -120,20 +120,20 @@ class TestAccountAnalyticPlanRequired(SavepointCase):
     def test_always_plan_no_analytic_plan_0(self):
         # accept missing analytic distribution when debit=credit=0
         self.account_type.write({
-            'analytic_policy': 'always_plan',
+            'property_analytic_policy': 'always_plan',
         })
         self._create_move(with_analytic=False, with_analytic_plan=False,
                           amount=0)
 
     def test_always_plan_with_analytic_plan(self):
         self.account_type.write({
-            'analytic_policy': 'always_plan',
+            'property_analytic_policy': 'always_plan',
         })
         self._create_move(with_analytic=False, with_analytic_plan=True)
 
     def test_always_plan_or_account_nothing(self):
         self.account_type.write({
-            'analytic_policy': 'always_plan_or_account',
+            'property_analytic_policy': 'always_plan_or_account',
         })
         with self.assertRaises(ValidationError):
             self._create_move(with_analytic=False, with_analytic_plan=False)
@@ -141,7 +141,7 @@ class TestAccountAnalyticPlanRequired(SavepointCase):
     def test_always_plan_or_account_no_analytic_plan_0(self):
         # accept missing analytic distribution when debit=credit=0
         self.account_type.write({
-            'analytic_policy': 'always_plan_or_account',
+            'property_analytic_policy': 'always_plan_or_account',
         })
         self._create_move(with_analytic=False, with_analytic_plan=False,
                           amount=0)
@@ -152,20 +152,20 @@ class TestAccountAnalyticPlanRequired(SavepointCase):
 
     def test_always_plan_or_account_with(self):
         self.account_id.user_type_id.write({
-            'analytic_policy': 'always_plan_or_account',
+            'property_analytic_policy': 'always_plan_or_account',
         })
         self._create_move(with_analytic=False, with_analytic_plan=True)
         self._create_move(with_analytic=True, with_analytic_plan=False)
 
     def test_never_no_analytic(self):
         self.account_type.write({
-            'analytic_policy': 'never',
+            'property_analytic_policy': 'never',
         })
         self._create_move(with_analytic=False, with_analytic_plan=False)
 
     def test_never_with_analytic(self):
         self.account_type.write({
-            'analytic_policy': 'never',
+            'property_analytic_policy': 'never',
         })
         with self.assertRaises(ValidationError):
             self._create_move(with_analytic=True, with_analytic_plan=False)
@@ -175,7 +175,7 @@ class TestAccountAnalyticPlanRequired(SavepointCase):
     def test_never_with_analytic_0(self):
         # accept analytic when debit=credit=0
         self.account_type.write({
-            'analytic_policy': 'never',
+            'property_analytic_policy': 'never',
         })
         self._create_move(with_analytic=True, with_analytic_plan=False,
                           amount=0)
@@ -185,7 +185,7 @@ class TestAccountAnalyticPlanRequired(SavepointCase):
     def test_always_remove_analytic_plan(self):
         # remove analytic plan account when policy is always
         self.account_type.write({
-            'analytic_policy': 'always_plan',
+            'property_analytic_policy': 'always_plan',
         })
         line_id = self._create_move(with_analytic=False,
                                     with_analytic_plan=True)
@@ -194,7 +194,7 @@ class TestAccountAnalyticPlanRequired(SavepointCase):
 
     def test_change_account(self):
         self.account_type.write({
-            'analytic_policy': 'always_plan',
+            'property_analytic_policy': 'always_plan',
         })
         # change account to a_expense with policy always_plan but missing
         # analytic distribution

--- a/account_analytic_required/__manifest__.py
+++ b/account_analytic_required/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 {
     'name': 'Account Analytic Required',
-    'version': '12.0.1.0.0',
+    'version': '12.0.2.0.0',
     'category': 'Analytic Accounting',
     'license': 'AGPL-3',
     'author': "Akretion, Odoo Community Association (OCA)",

--- a/account_analytic_required/migrations/12.0.2.0.0/post-migrate.py
+++ b/account_analytic_required/migrations/12.0.2.0.0/post-migrate.py
@@ -1,0 +1,55 @@
+from odoo import tools
+
+import logging
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+
+    _logger.debug('Migrating account.account.type analytic_policy')
+
+    if not tools.column_exists(cr, 'account_account_type', 'analytic_policy'):
+        return
+
+    cr.execute("SELECT id FROM res_company")
+    company_ids = [d[0] for d in cr.fetchall()]
+
+    cr.execute(
+        "SELECT id FROM ir_model_fields WHERE model=%s AND name=%s",
+        ('account.account.type', 'property_analytic_policy'))
+    [field_id] = cr.fetchone()
+
+    for company_id in company_ids:
+        cr.execute("""
+            INSERT INTO ir_property (
+                name,
+                type,
+                fields_id,
+                company_id,
+                res_id,
+                value_text
+            )
+            SELECT
+                '{field}',
+                'selection',
+                {field_id},
+                {company_id},
+                CONCAT('{model},',id),
+                {oldfield}
+            FROM {table} t
+            WHERE t.{oldfield} IS NOT NULL
+            AND NOT EXISTS(
+                SELECT 1
+                FROM ir_property
+                WHERE fields_id={field_id}
+                AND company_id={company_id}
+                AND res_id=CONCAT('{model},',t.id)
+            )
+        """.format(
+            oldfield='analytic_policy',
+            field='property_analytic_policy',
+            field_id=field_id,
+            company_id=company_id,
+            model='account.account.type',
+            table='account_account_type',
+        ))

--- a/account_analytic_required/migrations/12.0.2.0.0/post-migrate.py
+++ b/account_analytic_required/migrations/12.0.2.0.0/post-migrate.py
@@ -1,55 +1,15 @@
-from odoo import tools
+# Copyright 2020 Druidoo - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import logging
-_logger = logging.getLogger(__name__)
+from openupgradelib import openupgrade
 
 
-def migrate(cr, version):
-
-    _logger.debug('Migrating account.account.type analytic_policy')
-
-    if not tools.column_exists(cr, 'account_account_type', 'analytic_policy'):
-        return
-
-    cr.execute("SELECT id FROM res_company")
-    company_ids = [d[0] for d in cr.fetchall()]
-
-    cr.execute(
-        "SELECT id FROM ir_model_fields WHERE model=%s AND name=%s",
-        ('account.account.type', 'property_analytic_policy'))
-    [field_id] = cr.fetchone()
-
-    for company_id in company_ids:
-        cr.execute("""
-            INSERT INTO ir_property (
-                name,
-                type,
-                fields_id,
-                company_id,
-                res_id,
-                value_text
-            )
-            SELECT
-                '{field}',
-                'selection',
-                {field_id},
-                {company_id},
-                CONCAT('{model},',id),
-                {oldfield}
-            FROM {table} t
-            WHERE t.{oldfield} IS NOT NULL
-            AND NOT EXISTS(
-                SELECT 1
-                FROM ir_property
-                WHERE fields_id={field_id}
-                AND company_id={company_id}
-                AND res_id=CONCAT('{model},',t.id)
-            )
-        """.format(
-            oldfield='analytic_policy',
-            field='property_analytic_policy',
-            field_id=field_id,
-            company_id=company_id,
-            model='account.account.type',
-            table='account_account_type',
-        ))
+@openupgrade.migrate()
+def migrate(env, version):
+    # Convert analytic_policy to property_analytic_policy
+    openupgrade.convert_to_company_dependent(
+        env=env,
+        model_name="account.account.type",
+        origin_field_name="analytic_policy",
+        destination_field_name="property_analytic_policy",
+    )

--- a/account_analytic_required/models/account.py
+++ b/account_analytic_required/models/account.py
@@ -1,5 +1,6 @@
 # Copyright 2011-2016 Akretion - Alexis de Lattre
 # Copyright 2016 Camptocamp SA
+# Copyright 2020 Druidoo - Iván Todorovich
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import _, api, exceptions, fields, models
@@ -9,23 +10,29 @@ from odoo.tools import float_is_zero
 class AccountAccountType(models.Model):
     _inherit = "account.account.type"
 
-    analytic_policy = fields.Selection(
+    property_analytic_policy = fields.Selection(
         selection=[('optional', 'Optional'),
                    ('always', 'Always'),
                    ('posted', 'Posted moves'),
                    ('never', 'Never')],
         string='Policy for analytic account',
+        company_dependent=True,
         required=True,
         default='optional',
-        help="Set the policy for analytic accounts : if you select "
-             "'Optional', the accountant is free to put an analytic account "
-             "on an account move line with this type of account ; if you "
-             "select 'Always', the accountant will get an error message if "
-             "there is no analytic account ; if you select 'Posted moves', "
-             "the accountant will get an error message if no analytic account "
-             "is defined when the move is posted ; if you select 'Never', "
-             "the accountant will get an error message if an analytic account "
-             "is present.")
+        help=(
+            "Sets the policy for analytic accounts.\n"
+            "If you select:\n"
+            "- Optional: The accountant is free to put an analytic account "
+            "on an account move line with this type of account.\n"
+            "- Always: The accountant will get an error message if "
+            "there is no analytic account.\n"
+            "- Posted moves: The accountant will get an error message if no "
+            "analytic account is defined when the move is posted.\n"
+            "- Never: The accountant will get an error message if an analytic "
+            "account is present.\n\n"
+            "This field is company dependent."
+        ),
+    )
 
 
 class AccountMove(models.Model):
@@ -44,7 +51,9 @@ class AccountMoveLine(models.Model):
     @api.model
     def _get_analytic_policy(self, account):
         """ Extension point to obtain analytic policy for an account """
-        return account.user_type_id.analytic_policy
+        return account.user_type_id.with_context(
+            force_company=account.company_id.id,
+        ).property_analytic_policy
 
     @api.multi
     def _check_analytic_required_msg(self):

--- a/account_analytic_required/readme/CONFIGURE.rst
+++ b/account_analytic_required/readme/CONFIGURE.rst
@@ -4,3 +4,6 @@ If you want to have an analytic account on all your *expenses*,
 set the policy to *always* for the account type *expense*
 If you try to save an account move line with an account of type *expense*
 without analytic account, you will get an error message.
+
+The analytic policy is company dependent. If you have a multi-company
+environment, you should set its value for all companies.

--- a/account_analytic_required/readme/CONTRIBUTORS.rst
+++ b/account_analytic_required/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Raf Ven <raf.ven@dynapps.be>
+* Iván Todorovich <ivan.todorovich@druidoo.io>

--- a/account_analytic_required/tests/test_account_analytic_required.py
+++ b/account_analytic_required/tests/test_account_analytic_required.py
@@ -75,7 +75,7 @@ class TestAccountAnalyticRequired(common.SavepointCase):
     def _set_analytic_policy(self, policy, account=None):
         if account is None:
             account = self.account_sales
-        account.user_type_id.analytic_policy = policy
+        account.user_type_id.property_analytic_policy = policy
 
     def test_optional(self):
         self._set_analytic_policy('optional')

--- a/account_analytic_required/views/account.xml
+++ b/account_analytic_required/views/account.xml
@@ -12,7 +12,7 @@
     <field name="inherit_id" ref="account.view_account_type_form" />
     <field name="arch"  type="xml">
       <xpath expr="//group/group" position="inside">
-        <field name="analytic_policy" />
+        <field name="property_analytic_policy" />
       </xpath>
     </field>
   </record>
@@ -23,21 +23,7 @@
     <field name="inherit_id" ref="account.view_account_type_tree" />
     <field name="arch"  type="xml">
       <field name="type" position="after">
-        <field name="analytic_policy" />
-      </field>
-    </field>
-  </record>
-
-  <record id="view_account_type_search" model="ir.ui.view">
-    <field name="name">account_analytic_required.account_type_search</field>
-    <field name="model">account.account.type</field>
-    <field name="inherit_id" ref="account.view_account_type_search" />
-    <field name="arch"  type="xml">
-      <field name="name" position="after">
-        <group string="Group By" name="groupby">
-            <filter name="analytic_policy_groupby" string="Analytic Policy"
-                context="{'group_by': 'analytic_policy'}"/>
-        </group>
+        <field name="property_analytic_policy" />
       </field>
     </field>
   </record>


### PR DESCRIPTION
This PR converts the `analytic_policy` field to a company_dependent `property_analytic_policy` field.

In multi-company environments, `account.account.types` are shared among companies.

So, without this PR, it's impossible to set different analytic required policies to different companies (at least not without duplicating `account.types`, bad that results in ugly accounting setups)

The migration script takes care of migrating the current values to `ir.property` values.