### PR TITLE
[12.0][IMP] account_analytic_parent: filter using account or child accounts

### DIFF
--- a/account_analytic_parent/__manifest__.py
+++ b/account_analytic_parent/__manifest__.py
@@ -4,7 +4,7 @@
 # Copyright 2017 Deneroteam.
 # Copyright 2017 Serpent Consulting Services Pvt. Ltd.
 # Copyright 2017 Tecnativa
-# Copyright 2018 Brainbean Apps
+# Copyright 2018-2020 Brainbean Apps
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
@@ -27,6 +27,7 @@
     ],
     'data': [
         'views/account_analytic_account_view.xml',
+        'views/account_analytic_line.xml',
     ],
     'demo': [
         'data/analytic_account_demo.xml',

--- a/account_analytic_parent/views/account_analytic_line.xml
+++ b/account_analytic_parent/views/account_analytic_line.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 Brainbean Apps (https://brainbeanapps.com)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="view_account_analytic_line_filter" model="ir.ui.view">
+        <field name="name">account.analytic.line.filter</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_line_filter"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='account_id']" position="attributes">
+                <attribute name="operator">child_of</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Filtering analytic lines by analytic account will take into account child accounts as well

---
A note to myself: this is used in https://github.com/odoo/odoo/blob/7bf25cc333b0a3afc7e0a67f76f019407dba7e12/addons/web/static/src/js/views/search/search_inputs.js#L146 and also this is quite interesting https://github.com/odoo/odoo/blob/7bf25cc333b0a3afc7e0a67f76f019407dba7e12/addons/web/static/src/js/views/search/search_inputs.js#L492 