### PR TITLE
[11.0] [FIX] account_analytic_default_account: Be able to change account in invoice line.

### DIFF
--- a/account_analytic_default_account/models/account_analytic_default_account.py
+++ b/account_analytic_default_account/models/account_analytic_default_account.py
@@ -77,9 +77,23 @@ class AccountAnalyticDefaultAccount(models.Model):
 class AccountInvoiceLine(models.Model):
     _inherit = "account.invoice.line"
 
-    @api.onchange('product_id', 'account_id')
+    @api.onchange('product_id')
     def _onchange_product_id(self):
         res = super()._onchange_product_id()
+        if (not config['test_enable'] or
+                self.env.context.get('test_account_analytic_default_account')):
+            rec = self.env['account.analytic.default'].account_get(
+                product_id=self.product_id.id,
+                partner_id=self.invoice_id.partner_id.id,
+                user_id=self.env.uid, date=fields.Date.today(),
+                company_id=self.company_id.id, account_id=self.account_id.id
+            )
+            self.account_analytic_id = rec.analytic_id.id
+        return res
+
+    @api.onchange('account_id')
+    def _onchange_account_id(self):
+        res = super()._onchange_account_id()
         if (not config['test_enable'] or
                 self.env.context.get('test_account_analytic_default_account')):
             rec = self.env['account.analytic.default'].account_get(

--- a/account_analytic_default_account/tests/test_analytic_default_account.py
+++ b/account_analytic_default_account/tests/test_analytic_default_account.py
@@ -129,12 +129,28 @@ class TestAnalyticDefaultAccount(common.SavepointCase):
         )
         self.assertFalse(rec.id)
 
+    def test_change_account(self, invoice=False):
+        if not invoice:
+            invoice = self.create_invoice()
+        invoice.invoice_line_ids[0].account_id = self.account_sales
+        invoice.invoice_line_ids[0].with_context(
+            test_account_analytic_default_account=True)._onchange_account_id()
+
+    def test_change_product(self, invoice=False):
+        if not invoice:
+            invoice = self.create_invoice()
+        invoice.invoice_line_ids[0].product_id = self.product
+        invoice.invoice_line_ids[0].with_context(
+            test_account_analytic_default_account=True)._onchange_product_id()
+
     def test_account_analytic_default_invoice(self):
         invoice = self.create_invoice()
         self.assertFalse(invoice.invoice_line_ids[0].account_analytic_id.id)
         invoice.invoice_line_ids[0]._set_additional_fields(invoice)
         self.assertEqual(invoice.invoice_line_ids[0].account_analytic_id,
                          self.analytic_account_3)
+        self.test_change_account(invoice=invoice)
+        self.test_change_product(invoice=invoice)
 
     def test_account_analytic_default_account_move(self):
         move, move_line_1, move_line_2 = self.create_move()


### PR DESCRIPTION
The problem es related  to the trigger "account_id" in the on-change method "_onchange_product_id", this cause that if you try to change the account in the line then the method set newly the previous value and not take account the value who had crossed before.