### PR TITLE
[12.0][FIX] analytic_tag_dimension: avoid column not exists

### DIFF
--- a/analytic_tag_dimension/models/account_invoice_report.py
+++ b/analytic_tag_dimension/models/account_invoice_report.py
@@ -8,6 +8,8 @@ class AccountInvoiceReport(models.Model):
     _inherit = "account.invoice.report"
 
     def _get_dimension_fields(self):
+        if self.env.context.get("update_custom_fields"):
+            return []  # Avoid to report these columns when not yet created
         return [x for x in self.fields_get().keys()
                 if x.startswith("x_dimension_")]
 

--- a/analytic_tag_dimension/models/analytic.py
+++ b/analytic_tag_dimension/models/analytic.py
@@ -50,6 +50,8 @@ class AccountAnalyticDimension(models.Model):
                 'relation': 'account.analytic.tag',
             })],
         })
+        # Launch this manually for taking the new dimension field
+        self.env["account.invoice.report"].init()
         return res
 
     def write(self, vals):


### PR DESCRIPTION
Creating dimensions, you can face this error:
```
psycopg2.ProgrammingError: column ail.x_dimension_xxx does not exist
LINE 48:         , ail.x_dimension_xxx as x_dimension_xxx, ai.team_..
```
This is because the column is not yet populated in the moment when the model initialization is triggered.

In this commit, we inhibit the population of that field in the report on that case, and launching manual initialization later when done.

@Tecnativa TT24147