### PR TITLE
[12.0][FIX] account_analytic_parent: fix fr.po fieldnames

### DIFF
--- a/account_analytic_parent/i18n/fr.po
+++ b/account_analytic_parent/i18n/fr.po
@@ -79,7 +79,7 @@ msgstr "Il est interdit de créer des comptes analytiques récursifs."
 #: code:addons/account_analytic_parent/models/account_analytic_account.py:145
 #, python-format
 msgid "[%(code)s] %(name)s"
-msgstr "[%(code)s] %(name)s"
+msgstr ""
 
 #~ msgid "Created by"
 #~ msgstr "Créé par"

--- a/account_analytic_parent/i18n/fr.po
+++ b/account_analytic_parent/i18n/fr.po
@@ -79,7 +79,7 @@ msgstr "Il est interdit de créer des comptes analytiques récursifs."
 #: code:addons/account_analytic_parent/models/account_analytic_account.py:145
 #, python-format
 msgid "[%(code)s] %(name)s"
-msgstr "{%(code)s  %(nom)s"
+msgstr "[%(code)s] %(name)s"
 
 #~ msgid "Created by"
 #~ msgstr "Créé par"


### PR DESCRIPTION
There seemed to be an error in the `fr.po` translation, referencing the non-existing fieldname `nom` instead of `name`. This fixes that by un-translating that fieldname (and correcting the brackets). 

There didn't seem to be any similar errors in the other translations.

I don't know if the preferred way to specify 'there's no translation yet' in the OCA community is to have `msgstr` be the same as `msgid` (which I did here), or have `msgstr ""`. I found both cases in the other files.