### PR TITLE
[12.0][FIX+IMP]: analytic_partner_hr_timesheet: Proper partner smart-button

### DIFF
--- a/analytic_partner_hr_timesheet/models/res_partner.py
+++ b/analytic_partner_hr_timesheet/models/res_partner.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Tecnativa - Pedro M. Baeza
+# Copyright 2015-2020 Tecnativa - Pedro M. Baeza
 # Copyright 2017 Tecnativa - Luis M. Ontalba
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
@@ -17,5 +17,15 @@ class ResPartner(models.Model):
 
     @api.depends('timesheet_ids')
     def _compute_timesheet_count(self):
+        groups = self.env["account.analytic.line"].read_group(
+            [("other_partner_id", "in", self.ids),
+             ("project_id", "!=", False)],
+            ["other_partner_id"], ["other_partner_id"],
+        )
+        result = {
+            data['other_partner_id'][0]: (
+                data['other_partner_id_count']
+            ) for data in groups
+        }
         for partner in self:
-            partner.timesheet_count = len(partner.timesheet_ids)
+            partner.timesheet_count = result.get(partner.id, 0)

--- a/analytic_partner_hr_timesheet/tests/test_analytic_partner_hr_timesheet.py
+++ b/analytic_partner_hr_timesheet/tests/test_analytic_partner_hr_timesheet.py
@@ -27,6 +27,12 @@ class TestAnalyticPartnerHrTimesheet(common.SavepointCase):
             'account_id': cls.analytic_account.id,
             'name': 'Test Line',
             'partner_id': cls.partner_line.id,
+            'project_id': cls.project.id,
+        })
+        cls.line2 = cls.env['account.analytic.line'].create({
+            'account_id': cls.analytic_account.id,
+            'name': 'Test Line without project',
+            'partner_id': cls.partner_line.id,
         })
 
     def test_onchange_project_id(self):

--- a/analytic_partner_hr_timesheet/views/res_partner_views.xml
+++ b/analytic_partner_hr_timesheet/views/res_partner_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
             <xpath expr='//div[@name="button_box"]' position='inside'>
-                <button name="%(hr_timesheet.act_hr_timesheet_line)d"
+                <button name="%(hr_timesheet.timesheet_action_all)d"
                         type="action"
                         class="oe_inline oe_stat_button"
                         context="{'search_default_other_partner_id': active_id, 'default_other_partner_id': active_id}"


### PR DESCRIPTION
Two problems detected:

- The action linked to the smart-button always get to a restricted view where you only see your timesheets. Now linked other action that doesn't restrict that way, except what record rules do.
- The number of items specified doesn't take into account timesheet rules (lines without project), so we filter them. Also a performance patch has been done at the same time.

@Tecnativa TT24832