### PR TITLE
[IMP] 11.0 - Account Analytic Parent: add complete name

### DIFF
--- a/account_analytic_parent/models/account_analytic_account.py
+++ b/account_analytic_parent/models/account_analytic_account.py
@@ -14,7 +14,6 @@ class AccountAnalyticAccount(models.Model):
     _parent_name = "parent_id"
     _parent_store = True
     _parent_order = 'name'
-    _rec_name = 'display_name'
     _order = 'parent_left'
 
     parent_left = fields.Integer(
@@ -34,7 +33,13 @@ class AccountAnalyticAccount(models.Model):
     child_ids = fields.One2many(
         comodel_name="account.analytic.account",
         inverse_name="parent_id",
-        string="Child Accounts", copy=True)
+        string="Child Accounts", copy=True,
+    )
+    complete_name = fields.Char(
+        string='Complete Name',
+        compute='_compute_complete_name',
+        store=True,
+    )
 
     @api.multi
     def _compute_debit_credit_balance(self):
@@ -42,7 +47,7 @@ class AccountAnalyticAccount(models.Model):
         Warning, this method overwrites the standard because the hierarchy
         of analytic account changes
         """
-        super(AccountAnalyticAccount, self)._compute_debit_credit_balance()
+        super()._compute_debit_credit_balance()
         analytic_line_obj = self.env['account.analytic.line']
         # compute only analytic line
         for account in self.filtered(lambda x: x.child_ids):
@@ -63,6 +68,25 @@ class AccountAnalyticAccount(models.Model):
             account.credit = data_credit
             account.balance = account.credit - account.debit
 
+    @api.depends('name', 'parent_id.complete_name')
+    def _compute_complete_name(self):
+        for account in self:
+            if account.parent_id:
+                account.complete_name = _('%(parent)s / %(own)s') % {
+                    'parent': account.parent_id.complete_name,
+                    'own': account.name,
+                }
+            else:
+                account.complete_name = account.name
+
+    @api.depends(
+        'complete_name',
+        'code',
+        'partner_id.commercial_partner_id.name',
+    )
+    def _compute_display_name(self):
+        super()._compute_display_name()
+
     @api.multi
     @api.constrains("parent_id")
     def check_recursion(self):
@@ -73,37 +97,53 @@ class AccountAnalyticAccount(models.Model):
                 )
 
     @api.multi
+    @api.constrains('active')
+    def check_parent_active(self):
+        for account in self:
+            if (account.active and account.parent_id and
+                account.parent_id not in self and
+                not account.parent_id.active):
+                raise UserError(
+                    _('Please activate first parent account %s')
+                    % account.parent_id.display_name)
+
+    @api.multi
     @api.onchange("parent_id")
     def _onchange_parent_id(self):
         for account in self:
             account.partner_id = account.parent_id.partner_id
 
     @api.multi
-    @api.depends("name")
     def name_get(self):
         res = []
-        for account in self:
-            current = account
-            name = current.name
-            while current.parent_id:
-                name = "%s / %s" % (current.parent_id.name, name)
-                current = current.parent_id
-            res.append((account.id, name))
+        for analytic in self:
+            name = analytic.complete_name
+            if analytic.code:
+                name = _('[%(code)s] %(name)s') % {
+                    'code': analytic.code,
+                    'name': name,
+                }
+            if analytic.partner_id:
+                name = _('%(name)s - %(partner)s') % {
+                    'name': name,
+                    'partner': analytic.partner_id.commercial_partner_id.name,
+                }
+            res.append((analytic.id, name))
         return res
 
-    @api.multi
-    @api.constrains('active')
-    def check_parent_active(self):
-        for account in self:
-            if (account.active and account.parent_id and
-                    account.parent_id not in self and
-                    not account.parent_id.active):
-                raise UserError(
-                    _('Please activate first parent account %s')
-                    % account.parent_id.display_name)
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        res = super().name_search(
+            name, args, operator,limit)
+        if operator not in ('ilike', 'like', '=', '=like', '=ilike'):
+            return res
+        account_ids = {pair[0] for pair in res} if res else set()
+        recs = self.search([('complete_name', operator, name)])
+        account_ids.update(recs.ids)
+        return self.browse(account_ids).name_get()
 
     @api.multi
     def write(self, vals):
         if self and 'active' in vals and not vals['active']:
             self.mapped('child_ids').write({'active': False})
-        return super(AccountAnalyticAccount, self).write(vals)
+        return super().write(vals)

--- a/account_analytic_parent/views/account_analytic_account_view.xml
+++ b/account_analytic_parent/views/account_analytic_account_view.xml
@@ -13,4 +13,31 @@
         </field>
     </record>
 
+    <record id="view_account_analytic_account_list_inherit" model="ir.ui.view">
+        <field name="name">view.account.analytic.account.list.inherit</field>
+        <field name="model">account.analytic.account</field>
+        <field name="type">tree</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_account_list"/>
+        <field name="arch" type="xml">
+            <field name="display_name" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="display_name" position="after">
+                <field name="complete_name" string="Name"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_account_analytic_account_search_inherit" model="ir.ui.view">
+        <field name="name">view.account.analytic.account.search.inherit</field>
+        <field name="model">account.analytic.account</field>
+        <field name="type">search</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_account_search"/>
+        <field name="arch" type="xml">
+            <field name="name" position="attributes">
+                <attribute name="filter_domain">['|', '|', ('name','ilike',self), ('code','ilike',self), ('complete_name','ilike',self)]</attribute>
+            </field>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
* add: `complete_name` computed field
* add: override `name_search` so we can search by complete name
* imp: `name_get` backport from v12 and remove @api.depends decorator
* imp: search view - add complete name to name's filter_domain
* ref: move `_check_parent_active` so the structure is compliant with OCA guidelines
* ref: remove `super` arguments when possible