### PR TITLE
[12.0][IMP][product_analytic] - get income/expense analytic account/tag from the nearest parent category

### DIFF
--- a/product_analytic/models/account_invoice.py
+++ b/product_analytic/models/account_invoice.py
@@ -25,6 +25,9 @@ class AccountInvoiceLine(models.Model):
                 _get_product_analytic_accounts()
             ana_account = ana_accounts[INV_TYPE_MAP[inv_type]]
             self.account_analytic_id = ana_account.id
+            ana_tags = self.product_id.product_tmpl_id. \
+                _get_product_analytic_tag()[INV_TYPE_MAP[inv_type]]
+            self.analytic_tag_ids |= ana_tags
         return res
 
     @api.model_create_multi
@@ -39,4 +42,10 @@ class AccountInvoiceLine(models.Model):
                     _get_product_analytic_accounts()
                 ana_account = ana_accounts[INV_TYPE_MAP[inv_type]]
                 vals['account_analytic_id'] = ana_account.id
+                ana_tags = product.product_tmpl_id. \
+                    _get_product_analytic_tag()[INV_TYPE_MAP[inv_type]]
+                if ana_tags:
+                    if not vals.get('analytic_tag_ids'):
+                        vals['analytic_tag_ids'] = []
+                    vals['analytic_tag_ids'].append((4, ana_tags.id))
         return super().create(vals_list)

--- a/product_analytic/models/product.py
+++ b/product_analytic/models/product.py
@@ -21,9 +21,9 @@ class ProductTemplate(models.Model):
         self.ensure_one()
         return {
             'income': self.income_analytic_account_id or
-            self.categ_id.income_analytic_account_id,
+            self.categ_id.get_income_analytic_account(),
             'expense': self.expense_analytic_account_id or
-            self.categ_id.expense_analytic_account_id
+            self.categ_id.get_expense_analytic_account()
         }
 
 
@@ -36,3 +36,15 @@ class ProductCategory(models.Model):
     expense_analytic_account_id = fields.Many2one(
         'account.analytic.account', string='Expense Analytic Account',
         company_dependent=True)
+
+    def get_income_analytic_account(self):
+        self.ensure_one()
+        if not self.income_analytic_account_id and self.parent_id:
+            return self.parent_id.get_income_analytic_account()
+        return self.income_analytic_account_id
+
+    def get_expense_analytic_account(self):
+        self.ensure_one()
+        if not self.expense_analytic_account_id and self.parent_id:
+            return self.parent_id.get_expense_analytic_account()
+        return self.expense_analytic_account_id

--- a/product_analytic/models/product.py
+++ b/product_analytic/models/product.py
@@ -15,6 +15,16 @@ class ProductTemplate(models.Model):
     expense_analytic_account_id = fields.Many2one(
         'account.analytic.account', string='Expense Analytic Account',
         company_dependent=True)
+    income_analytic_tag_id = fields.Many2one(
+        'account.analytic.tag',
+        string='Income Analytic Tag',
+        company_dependent=True,
+    )
+    expense_analytic_tag_id = fields.Many2one(
+        'account.analytic.tag',
+        string='Expense Analytic Tag',
+        company_dependent=True,
+    )
 
     @api.multi
     def _get_product_analytic_accounts(self):
@@ -24,6 +34,16 @@ class ProductTemplate(models.Model):
             self.categ_id.get_income_analytic_account(),
             'expense': self.expense_analytic_account_id or
             self.categ_id.get_expense_analytic_account()
+        }
+
+    @api.multi
+    def _get_product_analytic_tag(self):
+        self.ensure_one()
+        return {
+            'income': self.income_analytic_tag_id
+            or self.categ_id.get_income_analytic_tag(),
+            'expense': self.expense_analytic_tag_id
+            or self.categ_id.get_expense_analytic_tag(),
         }
 
 
@@ -36,6 +56,28 @@ class ProductCategory(models.Model):
     expense_analytic_account_id = fields.Many2one(
         'account.analytic.account', string='Expense Analytic Account',
         company_dependent=True)
+    income_analytic_tag_id = fields.Many2one(
+        'account.analytic.tag',
+        string='Income Analytic Tag',
+        company_dependent=True,
+    )
+    expense_analytic_tag_id = fields.Many2one(
+        'account.analytic.tag',
+        string='Expense Analytic Tag',
+        company_dependent=True,
+    )
+
+    def get_income_analytic_tag(self):
+        self.ensure_one()
+        if not self.income_analytic_tag_id and self.parent_id:
+            return self.parent_id.get_income_analytic_tag()
+        return self.income_analytic_tag_id
+
+    def get_expense_analytic_tag(self):
+        self.ensure_one()
+        if not self.expense_analytic_tag_id and self.parent_id:
+            return self.parent_id.get_expense_analytic_tag()
+        return self.expense_analytic_tag_id
 
     def get_income_analytic_account(self):
         self.ensure_one()

--- a/product_analytic/readme/CONTRIBUTORS.rst
+++ b/product_analytic/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Luis M. Ontalba <luis.martinez@tecnativa.com>
 * David Vidal <david.vidal@tecnativa.com>
 * Thore Baden
+* Souheil Bejaoui <souheil.bejaoui@acsone.eu>

--- a/product_analytic/readme/DESCRIPTION.rst
+++ b/product_analytic/readme/DESCRIPTION.rst
@@ -1,4 +1,4 @@
-This module allows to define an analytic account at product or category level
+This module allows to define an analytic account and tag at product or category level
 for using it when creating invoices.
 
 This module is an alternative to the official module
@@ -7,5 +7,5 @@ This module is an alternative to the official module
 * it only depends on the *account* module, whereas the
   *account_analytic_default* module depends on *sale_stock* ;
 
-* the analytic account is configured on the product form or the product
+* the analytic account and tag are configured on the product form or the product
   category form, and not on a separate object.

--- a/product_analytic/readme/USAGE.rst
+++ b/product_analytic/readme/USAGE.rst
@@ -3,5 +3,5 @@ This module allows you to configure an **income analytic account** and an
 select the product in an invoice line, it will check if this product has an
 income analytic account (for customer invoice/refunds) or an expense analytic
 account (for supplier invoice/refunds) ; if it doesn't find any, it checks if
-the category of the product has an income or expense analytic account ; if an
+the category of the product (or the nearest parent category) has an income or expense analytic account ; if an
 analytic account is found, it will be set by default on the invoice line.

--- a/product_analytic/readme/USAGE.rst
+++ b/product_analytic/readme/USAGE.rst
@@ -1,7 +1,8 @@
-This module allows you to configure an **income analytic account** and an
-**expense analytic account** on products and on product categories. When you
+This module allows you to configure an **income analytic account/tag** and an
+**expense analytic account/tag** on products and on product categories. When you
 select the product in an invoice line, it will check if this product has an
-income analytic account (for customer invoice/refunds) or an expense analytic
-account (for supplier invoice/refunds) ; if it doesn't find any, it checks if
-the category of the product (or the nearest parent category) has an income or expense analytic account ; if an
-analytic account is found, it will be set by default on the invoice line.
+income analytic account/tag (for customer invoice/refunds) or an expense analytic
+account/tag (for supplier invoice/refunds) ; if it doesn't find any, it checks if
+the category of the product (or the nearest parent category) has an income or
+expense analytic account/tag ; if an analytic account/tag is found, it will be
+set by default on the invoice line.

--- a/product_analytic/tests/test_account_invoice.py
+++ b/product_analytic/tests/test_account_invoice.py
@@ -15,10 +15,18 @@ class TestAccountInvoiceLine(TransactionCase):
             'name': 'test analytic_account1'})
         self.analytic_account2 = self.env['account.analytic.account'].create({
             'name': 'test analytic_account2'})
+        self.analytic_tag1 = self.env["account.analytic.tag"].create(
+            {"name": "test analytic_tag1"}
+        )
+        self.analytic_tag2 = self.env["account.analytic.tag"].create(
+            {"name": "test analytic_tag2"}
+        )
         self.product2 = self.env['product.product'].create({
             'name': 'test product 02',
             'income_analytic_account_id': self.analytic_account1.id,
-            'expense_analytic_account_id': self.analytic_account2.id})
+            'expense_analytic_account_id': self.analytic_account2.id,
+            'income_analytic_tag_id': self.analytic_tag1.id,
+            'expense_analytic_tag_id': self.analytic_tag2.id})
         self.partner = self.env['res.partner'].create({
             'name': 'Test partner'})
         self.journal = self.env['account.journal'].create({
@@ -56,6 +64,18 @@ class TestAccountInvoiceLine(TransactionCase):
             self.invoice_line.account_analytic_id.id,
             self.product2.income_analytic_account_id.id
         )
+        self.assertEqual(
+            self.invoice_line.analytic_tag_ids,
+            self.product2.income_analytic_tag_id
+        )
+
+    def test_onchange_product_cumulative_analytic_tags(self):
+        self.invoice_line.product_id = self.product2.id
+        self.invoice_line.analytic_tag_ids |= self.analytic_tag2
+        self.invoice_line._onchange_product_id()
+        self.assertEqual(
+            self.invoice_line.analytic_tag_ids,
+            self.analytic_tag1 | self.analytic_tag2)
 
     def test_create_in(self):
         create_data = {
@@ -69,6 +89,45 @@ class TestAccountInvoiceLine(TransactionCase):
             {'inv_type': 'in_invoice'}).create(create_data)
         self.assertEqual(invoice_line2.account_analytic_id.id,
                          self.product2.expense_analytic_account_id.id)
+        self.assertEqual(
+            invoice_line2.analytic_tag_ids,
+            self.product2.expense_analytic_tag_id)
+
+    def test_create_in_cumulative_analytic_tags(self):
+        create_data = {
+            'name': 'Test Line',
+            'quantity': 1,
+            'price_unit': 1,
+            'account_id': self.account.id,
+            'product_id': self.product2.id,
+            'analytic_tag_ids': [(4, self.analytic_tag1.id)]
+        }
+        invoice_line = self.env['account.invoice.line'].with_context(
+            {'inv_type': 'in_invoice'}).create(create_data)
+        self.assertEqual(invoice_line.account_analytic_id.id,
+                         self.product2.expense_analytic_account_id.id)
+        self.assertEqual(
+            invoice_line.analytic_tag_ids,
+            self.analytic_tag1 | self.analytic_tag2)
+
+    def test_create_in_cumulative_analytic_tags_2(self):
+        create_data = {
+            'name': 'Test Line',
+            'quantity': 1,
+            'price_unit': 1,
+            'account_id': self.account.id,
+            'product_id': self.product2.id,
+            'analytic_tag_ids': [(4, self.analytic_tag1.id),
+                                 (0, 0, {"name": "test analytic_tag3"})]
+        }
+        invoice_line = self.env['account.invoice.line'].with_context(
+            {'inv_type': 'in_invoice'}).create(create_data)
+        self.assertEqual(invoice_line.account_analytic_id.id,
+                         self.product2.expense_analytic_account_id.id)
+        self.assertEqual(
+            set(invoice_line.analytic_tag_ids.mapped('name')),
+            set(("test analytic_tag1", "test analytic_tag2",
+                "test analytic_tag3")))
 
     def test_create_out(self):
         create_data = {
@@ -82,6 +141,127 @@ class TestAccountInvoiceLine(TransactionCase):
             {'inv_type': 'out_invoice'}).create(create_data)
         self.assertEqual(invoice_line3.account_analytic_id.id,
                          self.product2.income_analytic_account_id.id)
+        self.assertEqual(
+            invoice_line3.analytic_tag_ids,
+            self.product2.income_analytic_tag_id)
+
+    def test_create_out_with_categ_tag(self):
+        self.product2.income_analytic_tag_id = False
+        create_data = {
+            "name": "Test Line 1",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line1 = (
+            self.env["account.invoice.line"]
+                .with_context({"inv_type": "out_invoice"})
+                .create(create_data)
+        )
+        self.assertFalse(invoice_line1.analytic_tag_ids)
+        self.product2.categ_id = self.env["product.category"].create(
+            {
+                "name": "test category",
+                "income_analytic_tag_id": self.analytic_tag1.id,
+            }
+        )
+        create_data = {
+            "name": "Test Line 2",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line2 = (
+            self.env["account.invoice.line"]
+                .with_context({"inv_type": "out_invoice"})
+                .create(create_data)
+        )
+        self.assertEqual(
+            invoice_line2.analytic_tag_ids, self.analytic_tag1
+        )
+        self.product2.categ_id.income_analytic_tag_id = False
+        self.product2.categ_id.parent_id = self.env["product.category"].create(
+            {
+                "name": "test category",
+                "income_analytic_tag_id": self.analytic_tag2.id,
+            }
+        )
+        create_data = {
+            "name": "Test Line 3",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line3 = (
+            self.env["account.invoice.line"]
+                .with_context({"inv_type": "out_invoice"})
+                .create(create_data)
+        )
+        self.assertEqual(
+            invoice_line3.analytic_tag_ids, self.analytic_tag2
+        )
+
+    def test_create_in_with_categ_tag(self):
+        self.product2.expense_analytic_tag_id = False
+        create_data = {
+            "name": "Test Line 1",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line1 = (
+            self.env["account.invoice.line"]
+                .with_context({"inv_type": "in_invoice"})
+                .create(create_data)
+        )
+        self.assertFalse(invoice_line1.analytic_tag_ids)
+        self.product2.categ_id = self.env["product.category"].create(
+            {
+                "name": "test category",
+                "expense_analytic_tag_id": self.analytic_tag1.id,
+            }
+        )
+        create_data = {
+            "name": "Test Line 2",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line2 = (
+            self.env["account.invoice.line"]
+                .with_context({"inv_type": "in_invoice"})
+                .create(create_data)
+        )
+        self.assertEqual(
+            invoice_line2.analytic_tag_ids, self.analytic_tag1
+        )
+        self.product2.categ_id.expense_analytic_tag_id = False
+        self.product2.categ_id.parent_id = self.env["product.category"].create(
+            {
+                "name": "test category",
+                "expense_analytic_tag_id": self.analytic_tag2.id,
+            }
+        )
+        create_data = {
+            "name": "Test Line 3",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line3 = (
+            self.env["account.invoice.line"]
+                .with_context({"inv_type": "in_invoice"})
+                .create(create_data)
+        )
+        self.assertEqual(
+            invoice_line3.analytic_tag_ids, self.analytic_tag2
+        )
 
     def test_create_out_with_categ(self):
         self.product2.income_analytic_account_id = False

--- a/product_analytic/tests/test_account_invoice.py
+++ b/product_analytic/tests/test_account_invoice.py
@@ -82,3 +82,121 @@ class TestAccountInvoiceLine(TransactionCase):
             {'inv_type': 'out_invoice'}).create(create_data)
         self.assertEqual(invoice_line3.account_analytic_id.id,
                          self.product2.income_analytic_account_id.id)
+
+    def test_create_out_with_categ(self):
+        self.product2.income_analytic_account_id = False
+        create_data = {
+            "name": "Test Line 1",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line1 = (
+            self.env["account.invoice.line"]
+            .with_context({"inv_type": "out_invoice"})
+            .create(create_data)
+        )
+        self.assertFalse(invoice_line1.account_analytic_id)
+        self.product2.categ_id = self.env["product.category"].create(
+            {
+                "name": "test category",
+                "income_analytic_account_id": self.analytic_account1.id,
+            }
+        )
+        create_data = {
+            "name": "Test Line 2",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line2 = (
+            self.env["account.invoice.line"]
+            .with_context({"inv_type": "out_invoice"})
+            .create(create_data)
+        )
+        self.assertEqual(
+            invoice_line2.account_analytic_id, self.analytic_account1
+        )
+        self.product2.categ_id.income_analytic_account_id = False
+        self.product2.categ_id.parent_id = self.env["product.category"].create(
+            {
+                "name": "test category",
+                "income_analytic_account_id": self.analytic_account2.id,
+            }
+        )
+        create_data = {
+            "name": "Test Line 3",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line3 = (
+            self.env["account.invoice.line"]
+            .with_context({"inv_type": "out_invoice"})
+            .create(create_data)
+        )
+        self.assertEqual(
+            invoice_line3.account_analytic_id, self.analytic_account2
+        )
+
+    def test_create_in_with_categ(self):
+        self.product2.expense_analytic_account_id = False
+        create_data = {
+            "name": "Test Line 1",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line1 = (
+            self.env["account.invoice.line"]
+            .with_context({"inv_type": "in_invoice"})
+            .create(create_data)
+        )
+        self.assertFalse(invoice_line1.account_analytic_id)
+        self.product2.categ_id = self.env["product.category"].create(
+            {
+                "name": "test category",
+                "expense_analytic_account_id": self.analytic_account1.id,
+            }
+        )
+        create_data = {
+            "name": "Test Line 2",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line2 = (
+            self.env["account.invoice.line"]
+            .with_context({"inv_type": "in_invoice"})
+            .create(create_data)
+        )
+        self.assertEqual(
+            invoice_line2.account_analytic_id, self.analytic_account1
+        )
+        self.product2.categ_id.expense_analytic_account_id = False
+        self.product2.categ_id.parent_id = self.env["product.category"].create(
+            {
+                "name": "test category",
+                "expense_analytic_account_id": self.analytic_account2.id,
+            }
+        )
+        create_data = {
+            "name": "Test Line 3",
+            "quantity": 1,
+            "price_unit": 1,
+            "account_id": self.account.id,
+            "product_id": self.product2.id,
+        }
+        invoice_line3 = (
+            self.env["account.invoice.line"]
+            .with_context({"inv_type": "in_invoice"})
+            .create(create_data)
+        )
+        self.assertEqual(
+            invoice_line3.account_analytic_id, self.analytic_account2
+        )

--- a/product_analytic/views/product_view.xml
+++ b/product_analytic/views/product_view.xml
@@ -14,9 +14,11 @@
     <field name="arch" type="xml">
         <field name="property_account_income_id" position="after">
             <field name="income_analytic_account_id"/>
+            <field name="income_analytic_tag_id" groups="analytic.group_analytic_tags"/>
         </field>
         <field name="property_account_expense_id" position="after">
             <field name="expense_analytic_account_id"/>
+            <field name="expense_analytic_tag_id" groups="analytic.group_analytic_tags"/>
         </field>
     </field>
 </record>
@@ -28,9 +30,11 @@
     <field name="arch" type="xml">
         <field name="property_account_income_categ_id" position="after">
             <field name="income_analytic_account_id"/>
+            <field name="income_analytic_tag_id" groups="analytic.group_analytic_tags"/>
         </field>
         <field name="property_account_expense_categ_id" position="after">
             <field name="expense_analytic_account_id"/>
+            <field name="expense_analytic_tag_id" groups="analytic.group_analytic_tags"/>
         </field>
     </field>
 </record>


### PR DESCRIPTION
1. add default analytic tag to the product and category models
2. when the account/tag is not defined on the product and the category, get the nearest parent category with an account/tag