### PR TITLE
[12.0][FIX] analytic_tag_dimension_enhanced - domain filtered

### DIFF
--- a/analytic_tag_dimension_enhanced/views/account_invoice_view.xml
+++ b/analytic_tag_dimension_enhanced/views/account_invoice_view.xml
@@ -11,7 +11,7 @@
                     <field name="domain_tag_ids" invisible="1"/>
                 </xpath>
                 <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='analytic_tag_ids']" position="attributes">
-                    <attribute name="domain">[('id', 'in', domain_tag_ids or [])]</attribute>
+                    <attribute name="domain">['|', ('id', 'in', domain_tag_ids or []), ('analytic_dimension_id.by_sequence', '=', False)]</attribute>
                 </xpath>
             </data>
         </field>


### PR DESCRIPTION
cherry-pick from https://github.com/OCA/account-analytic/pull/318

Currently, if no Analytic Dimension with by_squence = True at all. The domain_tag_ids is computed as []. And hence, the domain will make no tag list at all (in fact, it should list all).