### PR TITLE
[13.0][ADD] procurement_mto_analytic - only add account_analytic_id in po domain if value is there

### DIFF
--- a/procurement_mto_analytic/models/stock_rule.py
+++ b/procurement_mto_analytic/models/stock_rule.py
@@ -17,11 +17,12 @@ class StockRule(models.Model):
 
     def _make_po_get_domain(self, company_id, values, partner):
         res = super()._make_po_get_domain(company_id, values, partner)
-        res += (
-            (
-                "order_line.account_analytic_id",
-                "=",
-                values.get("account_analytic_id", False),
-            ),
-        )
+        if "account_analytic_id" in values and values["account_analytic_id"]:
+            res += (
+                (
+                    "order_line.account_analytic_id",
+                    "=",
+                    values.get("account_analytic_id", False),
+                ),
+            )
         return res


### PR DESCRIPTION
This pr adapts method override _make_po_get_domain in procurement_mto_analytic.

Running scheduler to create purchase orders before this pr would create one purchase order per reordering rule. We do not want that.