### PR TITLE
[FIX] account_analytic_required: fix test

### DIFF
--- a/account_analytic_required/tests/test_account_analytic_required.py
+++ b/account_analytic_required/tests/test_account_analytic_required.py
@@ -142,7 +142,7 @@ class TestAccountAnalyticRequired(common.SavepointCase):
         self._set_analytic_policy("posted")
         line = self._create_move(with_analytic=False)
         move = line.move_id
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaises(exceptions.ValidationError), self.cr.savepoint():
             move.post()
         line.write({"analytic_account_id": self.analytic_account.id})
         move.post()


### PR DESCRIPTION
We need to rollback after the exception, otherwise the move stays posted
and the subsequent test isn't propperly evaluated

Solves https://github.com/OCA/account-analytic/issues/370

cc @Tecnativa TT27217