### PR TITLE
[11.0] [FIX] account_analytic_default_account: do not associate acoun…

### DIFF
--- a/account_analytic_default_account/models/account_analytic_default_account.py
+++ b/account_analytic_default_account/models/account_analytic_default_account.py
@@ -77,9 +77,7 @@ class AccountAnalyticDefaultAccount(models.Model):
 class AccountInvoiceLine(models.Model):
     _inherit = "account.invoice.line"
 
-    @api.onchange('product_id', 'account_id')
-    def _onchange_product_id(self):
-        res = super()._onchange_product_id()
+    def _set_account_analytic_id(self):
         if (not config['test_enable'] or
                 self.env.context.get('test_account_analytic_default_account')):
             rec = self.env['account.analytic.default'].account_get(
@@ -89,6 +87,17 @@ class AccountInvoiceLine(models.Model):
                 company_id=self.company_id.id, account_id=self.account_id.id
             )
             self.account_analytic_id = rec.analytic_id.id
+
+    @api.onchange('account_id')
+    def _onchange_account_id(self):
+        res = super()._onchange_account_id()
+        self._set_account_analytic_id()
+        return res
+
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        res = super()._onchange_product_id()
+        self._set_account_analytic_id()
         return res
 
     def _set_additional_fields(self, invoice):


### PR DESCRIPTION
…t_id with _onchange_product_id method

If we change the asset, it will change the account_id. Then if we associate in this module the execution of _onchange_product_id by dependency of account_id, the same method of the account_asset module will also be executed, so the selected asset will be changed by the one of the product that can be a different one.

I propose to change the account_id dependency to the _onchange_account_id method.