### PR TITLE
[14.0][FIX] analytic_tag_dimension_enhanced: not check required dimension in non-invoice

### DIFF
--- a/analytic_tag_dimension_enhanced/models/account_analytic_tag.py
+++ b/analytic_tag_dimension_enhanced/models/account_analytic_tag.py
@@ -18,7 +18,18 @@ class AccountAnalyticTag(models.Model):
     def _check_required_dimension(self, record):
         """Test all required dimension is selected (exclude non-invoice)"""
         record.ensure_one()
-        if "exclude_from_invoice_tab" in record and record.exclude_from_invoice_tab:
+        if (
+            record._name == "account.payment.register"
+            or (
+                "exclude_from_invoice_tab" in record and record.exclude_from_invoice_tab
+            )
+            or (
+                "move_id" in record
+                and "move_type" in record.move_id
+                and record.move_id.move_type == "entry"
+            )
+            or ("display_type" in record and record.display_type)
+        ):
             return
         Dimension = self.env["account.analytic.dimension"]
         req_dimensions = Dimension.search([("required", "=", True)])

--- a/analytic_tag_dimension_enhanced/tests/test_analytic_dimension.py
+++ b/analytic_tag_dimension_enhanced/tests/test_analytic_dimension.py
@@ -15,8 +15,15 @@ class TestAnalyticDimensionCase(TestAnalyticDimensionBase):
         cls.account_obj = cls.env["account.account"]
         cls.model_obj = cls.env["ir.model"]
         cls.field_obj = cls.env["ir.model.fields"]
+        cls.journal_purchase = cls.env["account.journal"].create(
+            {"name": "Test Purchase Journal", "code": "TPJ", "type": "purchase"}
+        )
         cls.invoice = cls.env["account.move"].create(
-            {"journal_id": cls.journal.id, "partner_id": cls.partner.id}
+            {
+                "move_type": "in_invoice",
+                "journal_id": cls.journal_purchase.id,
+                "partner_id": cls.partner.id,
+            }
         )
         # Mock data for testing model dimension, by_sequence with fitered
         vals = {


### PR DESCRIPTION
### Setting:
- Create analytic accounts dimensions
- Check **Require** in analytic accounts dimension

![Selection_164](https://user-images.githubusercontent.com/51266019/122009334-2ca23e80-cde4-11eb-925c-b43e6e5d22df.png)


### Before Fix: Error when create payment
![Selection_165](https://user-images.githubusercontent.com/51266019/122009716-8dca1200-cde4-11eb-8912-3cbf47c21b6e.png)


### After Fix: Can create payment
![Selection_166](https://user-images.githubusercontent.com/51266019/122009976-d71a6180-cde4-11eb-8ded-40a3a9a094c4.png)


