### PR TITLE
Fix name_get 

### DIFF
--- a/account_analytic_parent/models/account_analytic_account.py
+++ b/account_analytic_parent/models/account_analytic_account.py
@@ -149,7 +149,10 @@ class AccountAnalyticAccount(models.Model):
             if analytic.partner_id:
                 name = _('%(name)s - %(partner)s') % {
                     'name': name,
-                    'partner': analytic.partner_id.commercial_partner_id.name,
+                    if analytic.partner_id = analytic.partner_id.commercial_partner_id:
+                        'partner': ''
+                    else:
+                        'partner': analytic.partner_id.commercial_partner_id.name,
                 }
             res.append((analytic.id, name))
         return res


### PR DESCRIPTION
When partner_id and commercial_partner_id is the same, then name_get returns empty and odoo throws cache miss error.
This fixes this situation.