### PR TITLE
[FIX] analytic_activity_based_cost: rounding issue

### DIFF
--- a/analytic_activity_based_cost/models/product.py
+++ b/analytic_activity_based_cost/models/product.py
@@ -3,6 +3,7 @@
 
 
 from odoo import _, api, exceptions, fields, models
+from odoo.tools.float_utils import float_round
 
 
 class Product(models.Model):
@@ -31,6 +32,9 @@ class Product(models.Model):
         for product in self.filtered("is_cost_type"):
             if product.type in ["consu", "service"]:
                 product.standard_price = sum(
-                    x.standard_price * x.factor
+                    float_round(
+                        x.standard_price * x.factor,
+                        precision_rounding=product.currency_id.rounding,
+                    )
                     for x in product.sudo().activity_cost_ids
                 )

--- a/analytic_activity_based_cost/models/product.py
+++ b/analytic_activity_based_cost/models/product.py
@@ -29,12 +29,13 @@ class Product(models.Model):
     @api.onchange("activity_cost_ids")
     def onchange_for_standard_price(self):
         "Rollup Activity Costs to parent Cost Type"
+        precision = self.env["decimal.precision"].precision_get("Product Price")
         for product in self.filtered("is_cost_type"):
             if product.type in ["consu", "service"]:
                 product.standard_price = sum(
                     float_round(
                         x.standard_price * x.factor,
-                        precision_rounding=product.currency_id.rounding,
+                        precision_digits=precision,
                     )
                     for x in product.sudo().activity_cost_ids
                 )


### PR DESCRIPTION
Fixes rounding issue in journal items.

Previous behavior: product cost was calculated by sum of raw materials and activity costs multiplied by qty factor, then rounded. Journal items were calculated by each cost multiplied by a qty factor, then rounded individually. The sums do not always match.

Example:  A finished good product uses $0.87 in raw materials, labor is $31.66/hr and takes 15min, overhead is $44.66/hr and takes 15min. When calculating the cost of the finished good from the BoM, it calculates as $0.87 + $31.66/4 + $44.66/4 = $19.95. When the clearing lines are calculated, it gets $0.87 for raw materials, $31.66/4 = $7.915 ≅ $7.92 for labor, and $44.66/4 = $11.165 ≅ $11.17 for overhead. 0.87 + 7.92 + 11.17 = $19.96 which gives a $0.01 rounding error.

Solution: Round each activity cost before summing them into the finished good cost.