### PR TITLE
[14.0][IMP] stock_analytic: Add analytic on move lines tree view + store analytic account

### DIFF
--- a/stock_analytic/__manifest__.py
+++ b/stock_analytic/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Stock Analytic",
     "summary": "Adds an analytic account and analytic tags in stock move",
-    "version": "14.0.1.0.1",
+    "version": "14.0.2.0.0",
     "author": "Julius Network Solutions, "
     "ClearCorp, OpenSynergy Indonesia, "
     "Hibou Corp., "

--- a/stock_analytic/__manifest__.py
+++ b/stock_analytic/__manifest__.py
@@ -16,6 +16,10 @@
     "category": "Warehouse Management",
     "license": "AGPL-3",
     "depends": ["stock_account", "analytic"],
-    "data": ["views/stock_move_views.xml", "views/stock_scrap.xml"],
+    "data": [
+        "views/stock_move_views.xml",
+        "views/stock_scrap.xml",
+        "views/stock_move_line.xml",
+    ],
     "installable": True,
 }

--- a/stock_analytic/migrations/14.0.2.0.0/pre-migrate.py
+++ b/stock_analytic/migrations/14.0.2.0.0/pre-migrate.py
@@ -1,0 +1,29 @@
+# Copyright 2022 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+def _fill_in_move_line(env):
+    analytic_field = [
+        (
+            "analytic_account_id",
+            "stock.move.line",
+            "stock_move_line",
+            "many2one",
+            "int4",
+            "stock_analytic",
+        )
+    ]
+    openupgrade.add_fields(env, analytic_field)
+    query = """
+        UPDATE stock_move_line
+            SET analytic_account_id = sm.analytic_account_id
+            FROM stock_move sm WHERE sm.id = stock_move_line.move_id
+            AND sm.analytic_account_id IS NOT NULL
+    """
+    openupgrade.logged_query(env.cr, query)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _fill_in_move_line(env)

--- a/stock_analytic/views/stock_move_line.xml
+++ b/stock_analytic/views/stock_move_line.xml
@@ -24,4 +24,20 @@
         </field>
     </record>
 
+    <!-- In picking lines -->
+    <record id="view_move_line_detailed_tree" model="ir.ui.view">
+        <field name="name">stock.move.line.detailed.tree (in stock_analytic)</field>
+        <field name="model">stock.move.line</field>
+        <field
+            name="inherit_id"
+            ref="stock.view_stock_move_line_detailed_operation_tree"
+        />
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="analytic_account_id" optional="show" />
+            </field>
+        </field>
+    </record>
+
+
 </odoo>

--- a/stock_analytic/views/stock_move_line.xml
+++ b/stock_analytic/views/stock_move_line.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_move_line_tree" model="ir.ui.view">
+        <field name="name">stock.move.line.tree (in stock_analytic)</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_move_line_tree" />
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="analytic_account_id" optional="show" />
+            </field>
+        </field>
+    </record>
+
+    <record id="stock_move_line_view_search" model="ir.ui.view">
+        <field name="name">stock.move.line.search (in stock_analytic)</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.stock_move_line_view_search" />
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="analytic_account_id" />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This was intended to show the analytic account on move lines level.

So:

- [x] Add the analytic account on move line level views
- [x] Store the analytic account on move lines level in order to support extra move behaviour