### PR TITLE
[13.0][IMP] account_analtyic_parent - change action cost/revenue domain to child_of

### DIFF
--- a/account_analytic_parent/__manifest__.py
+++ b/account_analytic_parent/__manifest__.py
@@ -12,7 +12,7 @@
     "name": "Account Analytic Parent",
     "summary": """
         This module reintroduces the hierarchy to the analytic accounts.""",
-    "version": "13.0.1.1.1",
+    "version": "13.0.1.1.2",
     "license": "AGPL-3",
     "author": "Matmoz d.o.o., "
     "Luxim d.o.o., "

--- a/account_analytic_parent/readme/CONTRIBUTORS.rst
+++ b/account_analytic_parent/readme/CONTRIBUTORS.rst
@@ -12,3 +12,4 @@
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
 
 * Pedro Gonzalez <pedro.gonzalez@pesol.es>
+* Alberto Martín <alberto.martin@guadaltech.es>

--- a/account_analytic_parent/views/account_analytic_account_view.xml
+++ b/account_analytic_parent/views/account_analytic_account_view.xml
@@ -27,4 +27,8 @@
             </field>
         </field>
     </record>
+    <record id="analytic.account_analytic_line_action" model="ir.actions.act_window">
+        <field name="domain">[('account_id','child_of', [active_id])]</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Change to see with the button of the parent analyci line all the child's items.
Now, the compute of total balance include all childs items, but when you use the button in parent account, only show the direct items.