### PR TITLE
[FIX] Check account analytic on PO line candidate search.

### DIFF
--- a/procurement_mto_analytic/models/__init__.py
+++ b/procurement_mto_analytic/models/__init__.py
@@ -3,3 +3,4 @@
 from . import sale_order_line
 from . import stock_move
 from . import stock_rule
+from . import purchase_order_line

--- a/procurement_mto_analytic/models/purchase_order_line.py
+++ b/procurement_mto_analytic/models/purchase_order_line.py
@@ -1,0 +1,36 @@
+# Copyright 2022 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class PurchaseOrderLine(models.Model):
+
+    _inherit = "purchase.order.line"
+
+    def _find_candidate(
+        self,
+        product_id,
+        product_qty,
+        product_uom,
+        location_id,
+        name,
+        origin,
+        company_id,
+        values,
+    ):
+        line = super()._find_candidate(
+            product_id,
+            product_qty,
+            product_uom,
+            location_id,
+            name,
+            origin,
+            company_id,
+            values,
+        )
+        if values.get("account_analytic_id", False):
+            line = line.filtered_domain(
+                [("account_analytic_id", "=", values.get("account_analytic_id"))]
+            )
+        return line

--- a/procurement_mto_analytic/models/stock_rule.py
+++ b/procurement_mto_analytic/models/stock_rule.py
@@ -14,14 +14,3 @@ class StockRule(models.Model):
         )
         res.update({"account_analytic_id": values.get("account_analytic_id", False)})
         return res
-
-    def _make_po_get_domain(self, company_id, values, partner):
-        res = super()._make_po_get_domain(company_id, values, partner)
-        res += (
-            (
-                "order_line.account_analytic_id",
-                "=",
-                values.get("account_analytic_id", False),
-            ),
-        )
-        return res


### PR DESCRIPTION
Currently we search on SO analytic account during the PO candidate search phase.
If there is a PO for the selected supplier but there is no lines with the current analytic account, the po is ne selected
The verification of the analytic account should only be done during the Detection phase of a candidate purchase line. At this moment we can check if the candidate line has the same analytic account and if so, select it or ignore it.

Video link to see the current behavior : https://youtu.be/Q4DXCCMzt0c