### PR TITLE
[11.0][FIX] pos_analytic_by_config: force analytic account

### DIFF
--- a/pos_analytic_by_config/README.rst
+++ b/pos_analytic_by_config/README.rst
@@ -72,6 +72,10 @@ Contributors
 
   * David Vidal
 
+* `Factor Libre S.L. <https://factorlibre.com/>`_
+
+  * Luis J. Salvatierra <luis.salvatierra@factorlibre.com>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/pos_analytic_by_config/__manifest__.py
+++ b/pos_analytic_by_config/__manifest__.py
@@ -8,7 +8,7 @@
               'Odoo Community Association (OCA)',
     'website': "https://github.com/OCA/account-analytic",
     'category': 'Point Of Sale, Accounting',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'license': 'AGPL-3',
     'depends': [
         'point_of_sale',

--- a/pos_analytic_by_config/models/pos_order.py
+++ b/pos_analytic_by_config/models/pos_order.py
@@ -1,5 +1,6 @@
 # Copyright 2015 ACSONE SA/NV
 # Copyright 2020 Tecnativa - David Vidal
+# Copyright 2022 FactorLibre - Luis J. Salvatierra <luis.salvatierra@factorlibre.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import models, api
 
@@ -14,3 +15,11 @@ class PosOrder(models.Model):
     def action_pos_order_invoice(self):
         self_ctx = self.with_context(pos_analytic=True)
         return super(PosOrder, self_ctx).action_pos_order_invoice()
+
+    def _action_create_invoice_line(self, line=False, invoice_id=False):
+        account_analytic = self._prepare_analytic_account(line)
+        inv_line = super()._action_create_invoice_line(line=line, invoice_id=invoice_id)
+        if account_analytic:
+            # Force Analytic Account in case onchange method on product discard it.
+            inv_line.account_analytic_id = account_analytic
+        return inv_line

--- a/pos_analytic_by_config/readme/CONTRIBUTORS.rst
+++ b/pos_analytic_by_config/readme/CONTRIBUTORS.rst
@@ -6,3 +6,7 @@
 * `Tecnativa <https://www.tecnativa.com>`_
 
   * David Vidal
+
+* `Factor Libre S.L. <https://factorlibre.com/>`_
+
+  * Luis J. Salvatierra <luis.salvatierra@factorlibre.com>


### PR DESCRIPTION
In some rare cases, the inheritance over the product onchange method does not get called, and the one from the Point of Sale discards the analytic account.