### PR TITLE
[15.0][IMP] purchase_analytic: adapt to newest framework.

### DIFF
--- a/purchase_analytic/models/purchase.py
+++ b/purchase_analytic/models/purchase.py
@@ -1,4 +1,5 @@
 # © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
@@ -7,54 +8,39 @@ from odoo import api, fields, models
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
-    project_id2 = fields.Many2one(
-        comodel_name="account.analytic.account",
-        help="Use to store the value of project_id if there is no lines",
-    )
     project_id = fields.Many2one(
         compute="_compute_project_id",
         inverse="_inverse_project_id",
         comodel_name="account.analytic.account",
-        string="Contract / Analytic",
+        string="Analytic Account",
         readonly=True,
         states={"draft": [("readonly", False)]},
         store=True,
-        help="The analytic account related to a sales order.",
+        help="The analytic account related to a purchase order.",
     )
 
     @api.depends("order_line.account_analytic_id")
     def _compute_project_id(self):
-        """If all order line have same analytic account set project_id"""
+        """If all order line have same analytic account set project_id.
+        If no lines, respect value given by the user.
+        """
         for po in self:
-            al = po.project_id2
             if po.order_line:
                 al = po.order_line[0].account_analytic_id or False
                 for ol in po.order_line:
                     if ol.account_analytic_id != al:
                         al = False
                         break
-            po.project_id = al
+                po.project_id = al
 
     def _inverse_project_id(self):
         """When set project_id set analytic account on all order lines"""
         for po in self:
             if po.project_id:
                 po.order_line.write({"account_analytic_id": po.project_id.id})
-            po.project_id2 = po.project_id
 
     @api.onchange("project_id")
     def _onchange_project_id(self):
-        """When change project_id set analytic account on all order lines
-        Do it in one operation to avoid to recompute the project_id field
-        during the change.
-        In case of new record, nothing is recomputed to avoid ugly message
-        """
-        r = []
-        for ol in self.order_line:
-            if isinstance(ol.id, int):
-                r.append((1, ol.id, {"account_analytic_id": self.project_id.id}))
-            else:
-                # this is new record, do nothing !
-                return
-        self.project_id2 = self.project_id
-        self.order_line = r
+        """When change project_id set analytic account on all order lines"""
+        if self.project_id:
+            self.order_line.update({"account_analytic_id": self.project_id.id})

--- a/purchase_analytic/readme/CONTRIBUTORS.rst
+++ b/purchase_analytic/readme/CONTRIBUTORS.rst
@@ -4,3 +4,5 @@
 * `Jarsa <https://www.jarsa.com>`_
 
   * Alan Ramos
+
+* Lois Rilo <lois.rilo@forgeflow.com>

--- a/purchase_analytic/tests/test_purchase_analytic.py
+++ b/purchase_analytic/tests/test_purchase_analytic.py
@@ -19,7 +19,7 @@ class TestPurchaseAnalytic(TransactionCase):
     def test_analytic_account(self):
         """Create a purchase order (create)
         Set analytic account on purchase
-        Check analytic account on line is set
+        Check analytic account and line is set
         """
         po = self.env["purchase.order"].create(
             {
@@ -48,7 +48,7 @@ class TestPurchaseAnalytic(TransactionCase):
     def test_project_id(self):
         """Create a purchase order (new)
         Set analytic account on purchase
-        Check analytic account is on purchase
+        Check analytic account and line is set
         """
         po = self.env["purchase.order"].new(
             {
@@ -72,4 +72,4 @@ class TestPurchaseAnalytic(TransactionCase):
         )
         po._onchange_project_id()
         self.assertEqual(po.project_id.id, self.project.id)
-        self.assertFalse(po.order_line.account_analytic_id)
+        self.assertEqual(po.order_line.account_analytic_id.id, self.project.id)

--- a/purchase_analytic/views/purchase_views.xml
+++ b/purchase_analytic/views/purchase_views.xml
@@ -29,7 +29,6 @@
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
             <field name="partner_ref" position="after">
-                <field name="project_id2" invisible="1" />
                 <field
                     name="project_id"
                     groups="analytic.group_analytic_accounting"


### PR DESCRIPTION
Forward port of #473 

Some of the "tricks" done in this module are no longer needed
and can be easily implemented with newest framework features:

* No need for an auxiliar `project_id2` field. User can set
  an analytic account with no lines and it is respected.
* Simplify onchange. Now update analytic line on the go (no
  need to save) which is a better UX because avoid unexpected
  changes on save.

Also re-label the field `project_id` to "Analytic Account" to
align with the typical label in newer versions of Odoo.
Tha label "Contract / Analytic" was last used in v8 (
https://github.com/odoo/odoo/blob/8.0/addons/sale/sale.py#L217).

@ForgeFlow