### PR TITLE
[15.0][FIX] account_analytic_sequence: Make sequence multi-company by default

### DIFF
--- a/account_analytic_sequence/data/sequence.xml
+++ b/account_analytic_sequence/data/sequence.xml
@@ -8,6 +8,7 @@
         <field name="code">account.analytic.account.code</field>
         <field name="prefix">AA</field>
         <field name="padding">3</field>
+        <field name="company_id" eval="False" />
     </record>
 
 </odoo>


### PR DESCRIPTION
For avoiding an error in secondary companies when creating analytic accounts there.

Steps to reproduce:

- Have an instance with at least 2 companies.
- Install module with one company as main.
- Switch to the other company.
- Create an analytic account.

It will give an error.

No regression test is provided this time as it will require a lot of code for something fixed just with not filling a field.

@Tecnativa