### PR TITLE
[15.0][FIX][IMP] purchase_analytic: Fix deletion of analytic_id by onchange method

### DIFF
--- a/purchase_analytic/models/purchase.py
+++ b/purchase_analytic/models/purchase.py
@@ -44,3 +44,12 @@ class PurchaseOrder(models.Model):
         """When change project_id set analytic account on all order lines"""
         if self.project_id:
             self.order_line.update({"account_analytic_id": self.project_id.id})
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    @api.onchange("product_id")
+    def onchange_set_account_analytic_id(self):
+        """Set the account_analytic_id on the onchange method.."""
+        self.account_analytic_id = self.order_id._origin.project_id


### PR DESCRIPTION
The analytic accounts are corretly set with the compute method.
When using the GUI, the analytic account on the orderline was overriden by the onchange method.

This PR adds the analytic account to the onchange method.