### PR TITLE
[16.0][IMP] stock_analytic: more granularity on applicability judgment

### DIFF
--- a/stock_analytic/README.rst
+++ b/stock_analytic/README.rst
@@ -62,6 +62,20 @@ contain journal items with following rule:
    assigned to an analytic account according to the stock move's analytic
    account.
 
+Analytic applicability judgment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Applicability of the analytic distribution is judged based on the applicability
+settings of the analytic plan.
+
+Note that this module adds the 'Stock Move' option to the business domain, and
+'Operation Type' field.
+
+Return moves are currently outside the scope of the validation / applicability judgment
+(i.e. treated the same as optional) to allow some flexibility in the operation since
+multiple factors (e.g. applicability of the original move) may need to be considered
+to correctly judge the applicability.
+
 Bug Tracker
 ===========
 

--- a/stock_analytic/__manifest__.py
+++ b/stock_analytic/__manifest__.py
@@ -18,6 +18,7 @@
     "license": "AGPL-3",
     "depends": ["stock_account", "analytic"],
     "data": [
+        "views/account_analytic_plan_views.xml",
         "views/stock_move_views.xml",
         "views/stock_scrap_views.xml",
         "views/stock_move_line_views.xml",

--- a/stock_analytic/models/analytic_applicability.py
+++ b/stock_analytic/models/analytic_applicability.py
@@ -11,3 +11,21 @@ class AccountAnalyticApplicability(models.Model):
         selection_add=[("stock_move", "Stock Move")],
         ondelete={"stock_move": "cascade"},
     )
+    stock_picking_type_id = fields.Many2one(
+        "stock.picking.type",
+        string="Operation Type",
+    )
+
+    def _get_score(self, **kwargs):
+        score = super()._get_score(**kwargs)
+        if score == -1:
+            return -1
+        picking_type = self.env["stock.picking.type"].browse(
+            kwargs.get("picking_type", None)
+        )
+        if picking_type and self.stock_picking_type_id:
+            if picking_type == self.stock_picking_type_id:
+                score += 1
+            else:
+                return -1
+        return score

--- a/stock_analytic/readme/USAGE.rst
+++ b/stock_analytic/readme/USAGE.rst
@@ -17,3 +17,17 @@ contain journal items with following rule:
 #. Journal item with account different to product's valuation account will be
    assigned to an analytic account according to the stock move's analytic
    account.
+
+Analytic applicability judgment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Applicability of the analytic distribution is judged based on the applicability
+settings of the analytic plan.
+
+Note that this module adds the 'Stock Move' option to the business domain, and
+'Operation Type' field.
+
+Return moves are currently outside the scope of the validation / applicability judgment
+(i.e. treated the same as optional) to allow some flexibility in the operation since
+multiple factors (e.g. applicability of the original move) may need to be considered
+to correctly judge the applicability.

--- a/stock_analytic/static/description/index.html
+++ b/stock_analytic/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Stock Analytic</title>
 <style type="text/css">
 
@@ -377,13 +377,14 @@ analytic information when generating the journal items.</p>
 <li><a class="reference internal" href="#usage" id="id2">Usage</a><ul>
 <li><a class="reference internal" href="#to-assign-an-analytic-account-to-a-stock-move" id="id3">To Assign an Analytic Account to a Stock Move</a></li>
 <li><a class="reference internal" href="#assigned-journal-items-created-from-stock-move-with-analytic-account" id="id4">Assigned Journal Items created from Stock Move with Analytic Account</a></li>
+<li><a class="reference internal" href="#analytic-applicability-judgment" id="id5">Analytic applicability judgment</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="id5">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id6">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id7">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id8">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id9">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id6">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id7">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id8">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id9">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id10">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -415,9 +416,20 @@ assigned to an analytic account according to the stock move’s analytic
 account.</li>
 </ol>
 </div>
+<div class="section" id="analytic-applicability-judgment">
+<h2><a class="toc-backref" href="#id5">Analytic applicability judgment</a></h2>
+<p>Applicability of the analytic distribution is judged based on the applicability
+settings of the analytic plan.</p>
+<p>Note that this module adds the ‘Stock Move’ option to the business domain, and
+‘Operation Type’ field.</p>
+<p>Return moves are currently outside the scope of the validation / applicability judgment
+(i.e. treated the same as optional) to allow some flexibility in the operation since
+multiple factors (e.g. applicability of the original move) may need to be considered
+to correctly judge the applicability.</p>
+</div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id5">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id6">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-analytic/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -425,9 +437,9 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id6">Credits</a></h1>
+<h1><a class="toc-backref" href="#id7">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id7">Authors</a></h2>
+<h2><a class="toc-backref" href="#id8">Authors</a></h2>
 <ul class="simple">
 <li>Julius Network Solutions</li>
 <li>ClearCorp</li>
@@ -436,7 +448,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id8">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id9">Contributors</a></h2>
 <ul class="simple">
 <li>Hanane ELKHAL &lt;<a class="reference external" href="mailto:hanane&#64;julius.fr">hanane&#64;julius.fr</a>&gt;</li>
 <li>Yvan Patry &lt;<a class="reference external" href="mailto:yvan&#64;julius.fr">yvan&#64;julius.fr</a>&gt;</li>
@@ -456,7 +468,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id9">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id10">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/stock_analytic/tests/test_stock_picking.py
+++ b/stock_analytic/tests/test_stock_picking.py
@@ -58,14 +58,6 @@ class TestStockPicking(TransactionCase):
         cls.analytic_distribution = dict(
             {str(cls.env.ref("analytic.analytic_agrolait").id): 100.0}
         )
-        # analytic.analytic_agrolait belongs to analytic.analytic_plan_projects
-        cls.analytic_applicability = cls.env["account.analytic.applicability"].create(
-            {
-                "business_domain": "stock_move",
-                "applicability": "optional",
-                "analytic_plan_id": cls.env.ref("analytic.analytic_plan_projects").id,
-            }
-        )
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.location = cls.warehouse.lot_stock_id
         cls.dest_location = cls.env.ref("stock.stock_location_customers")
@@ -82,6 +74,16 @@ class TestStockPicking(TransactionCase):
             }
         )
         cls.product.update({"categ_id": cls.product_categ.id})
+
+    def _create_analytic_applicability(self):
+        # analytic.analytic_agrolait belongs to analytic.analytic_plan_projects
+        return self.env["account.analytic.applicability"].create(
+            {
+                "business_domain": "stock_move",
+                "applicability": "optional",
+                "analytic_plan_id": self.env.ref("analytic.analytic_plan_projects").id,
+            }
+        )
 
     def _create_picking(
         self,
@@ -172,6 +174,17 @@ class TestStockPicking(TransactionCase):
         self._check_analytic_account_no_error(picking)
 
     def test_outgoing_picking_without_analytic_optional(self):
+        # Create a general optional applicability for stock moves.
+        self._create_analytic_applicability()
+        # Create a another applicability which makes the analytic mandatory only for
+        # incoming stock moves. i.e. applicability should be optional for the outgoing
+        applicability_specific = self._create_analytic_applicability()
+        applicability_specific.write(
+            {
+                "stock_picking_type_id": self.incoming_picking_type.id,
+                "applicability": "mandatory",
+            }
+        )
         picking = self._create_picking(
             self.location,
             self.dest_location,
@@ -184,7 +197,15 @@ class TestStockPicking(TransactionCase):
         self._check_no_analytic_account(picking)
 
     def test_outgoing_picking_without_analytic_mandatory(self):
-        self.analytic_applicability.write({"applicability": "mandatory"})
+        # Create a general mandatory applicability for stock moves.
+        applicability_general = self._create_analytic_applicability()
+        applicability_general.write({"applicability": "mandatory"})
+        # Create a another applicability which makes the analytic optional only for
+        # incoming stock moves.
+        applicability_specific = self._create_analytic_applicability()
+        applicability_specific.write(
+            {"stock_picking_type_id": self.incoming_picking_type.id}
+        )
         picking = self._create_picking(
             self.location,
             self.dest_location,

--- a/stock_analytic/views/account_analytic_plan_views.xml
+++ b/stock_analytic/views/account_analytic_plan_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="account_analytic_plan_form_view" model="ir.ui.view">
+        <field name="name">account.analytic.plan.form</field>
+        <field name="model">account.analytic.plan</field>
+        <field name="inherit_id" ref="analytic.account_analytic_plan_form_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='applicability_ids']//field[@name='business_domain']"
+                position="after"
+            >
+                <field
+                    name="stock_picking_type_id"
+                    attrs="{'readonly': [('business_domain', '!=', 'stock_move')]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this commit, analytic distribution would be validated only for outgoing moves, which was not ideal in view of a module such as purchase_stock_analytic.

This commit adds more flexibility to the applicability judgment by adding the stock picking type field to the analytic applicability model, removing the assumption of validating outgoing moves only.

@qrtl
