### PR TITLE
[IMP] purchase_analytic: fix project_id being erase after selecting p…

### DIFF
--- a/purchase_analytic/models/purchase.py
+++ b/purchase_analytic/models/purchase.py
@@ -53,12 +53,16 @@ class PurchaseOrder(models.Model):
             In case of new record, nothing is recomputed to avoid ugly message
         """
         r = []
+        self._reset_sequence()
         for ol in self.order_line:
             if isinstance(ol.id, int):
                 r.append((1, ol.id,
                           {'account_analytic_id': self.project_id.id}))
             else:
+                if isinstance(ol.id, models.NewId):
+                    ol.account_analytic_id = self.project_id.id
+                else:
+                    return
                 # this is new record, do nothing !
-                return
         self.project_id2 = self.project_id
         self.order_line = r


### PR DESCRIPTION
Old behavior: When selecting a new product the analytic account gets erased
Current behavior: the new added line gets the analytic account assigned  