### PR TITLE
[15.0][FIX] account_tag_dimension: fix permission sudo for allow modify ir.model

### DIFF
--- a/analytic_tag_dimension/models/account_analytic_dimension.py
+++ b/analytic_tag_dimension/models/account_analytic_dimension.py
@@ -57,8 +57,10 @@ class AccountAnalyticDimension(models.Model):
     @api.model
     def create(self, values):
         res = super().create(values)
-        _models = self.env["ir.model"].search(
-            [("model", "in", self.get_model_names())], order="id"
+        _models = (
+            self.env["ir.model"]
+            .sudo()
+            .search([("model", "in", self.get_model_names())], order="id")
         )
         _models.write(
             {


### PR DESCRIPTION
Step to error:
1. install module `account_tag_dimension`
2. create user accounting
3. create dimension > Save > Error
![Selection_006](https://github.com/OCA/account-analytic/assets/20896369/4dfb4987-abdd-4e97-a9d2-f404b5af09c6)

This PR add permission for allow create analytic tag dimension