### PR TITLE
[15.0][ENH] stock_analytic: select analytic when scrapping product

### DIFF
--- a/stock_analytic/readme/CONTRIBUTORS.rst
+++ b/stock_analytic/readme/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@
 * Jared Kipe <jared@hibou.io>
 * Alan Ramos <alan.ramos@jarsa.com.mx>
 * Mantas Šniukas <mantas@vialaurea.lt>
+* Pimolnat Suntian <pimolnats@ecosoft.co.th>

--- a/stock_analytic/views/stock_scrap.xml
+++ b/stock_analytic/views/stock_scrap.xml
@@ -17,4 +17,22 @@
             </xpath>
         </field>
     </record>
+    <record id="stock_scrap_form_view2" model="ir.ui.view">
+        <field name="name">stock.scrap.analytic.form2</field>
+        <field name="model">stock.scrap</field>
+        <field name="inherit_id" ref="stock.stock_scrap_form_view2" />
+        <field name="arch" type="xml">
+            <xpath expr="//group/group[1]" position="inside">
+                <field
+                    name="analytic_account_id"
+                    groups="analytic.group_analytic_accounting"
+                />
+                <field
+                    name="analytic_tag_ids"
+                    widget="many2many_tags"
+                    groups="analytic.group_analytic_tags"
+                />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This PR is used to select Analytic Account and Analytic Tags when scrapping products.
![Selection_123](https://github.com/OCA/account-analytic/assets/51266019/f6cf7a1d-a157-4c25-bc6c-8bf8140d767c)
