### PR TITLE
[16.0][IMP] stock_analytic: add analytic distribution to move tree re…

### DIFF
--- a/stock_analytic/views/stock_move_views.xml
+++ b/stock_analytic/views/stock_move_views.xml
@@ -46,4 +46,21 @@
             </xpath>
         </field>
     </record>
+    <record
+        id="view_move_tree_receipt_picking_inherit_analytic_account"
+        model="ir.ui.view"
+    >
+        <field name="name">stock.move.tree2 - Analytic Account</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_move_tree_receipt_picking" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='location_dest_id']" position="after">
+                <field
+                    name="analytic_distribution"
+                    widget="analytic_distribution"
+                    groups="analytic.group_analytic_accounting"
+                />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
…ceipt picking view
Forward port of https://github.com/OCA/account-analytic/pull/564.
Field "analytic_account_id" does not longer exist in model "stock.move" so instead "analytic_distribution" field is being used.