### PR TITLE
[15.0][FIX] account_move_update_analytic: Switch button text to icon

### DIFF
--- a/account_move_update_analytic/__manifest__.py
+++ b/account_move_update_analytic/__manifest__.py
@@ -17,4 +17,5 @@
         "views/account_move_line_view.xml",
     ],
     "installable": True,
+    "maintainers": ["remi-filament", "Shide"],
 }

--- a/account_move_update_analytic/i18n/account_move_update_analytic.pot
+++ b/account_move_update_analytic/i18n/account_move_update_analytic.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-09-21 06:59+0000\n"
+"PO-Revision-Date: 2023-09-21 06:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -106,13 +108,6 @@ msgid "New Analytic Tags"
 msgstr ""
 
 #. module: account_move_update_analytic
-#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.account_move_form_view
-#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.account_move_line_tree_view
-#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.view_move_line_tree_grouped
-msgid "Update Analytic"
-msgstr ""
-
-#. module: account_move_update_analytic
 #: model_terms:ir.ui.view,arch_db:account_move_update_analytic.view_account_move_update_analytic_account
 msgid "Update Analytic Accounts / Tags"
 msgstr ""
@@ -120,6 +115,13 @@ msgstr ""
 #. module: account_move_update_analytic
 #: model:ir.actions.act_window,name:account_move_update_analytic.action_view_account_move_update_analytic
 msgid "Update Analytic for selected Account Moves"
+msgstr ""
+
+#. module: account_move_update_analytic
+#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.account_move_form_view
+#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.account_move_line_tree_view
+#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.view_move_line_tree_grouped
+msgid "Update analytic account and tags"
 msgstr ""
 
 #. module: account_move_update_analytic

--- a/account_move_update_analytic/i18n/es.po
+++ b/account_move_update_analytic/i18n/es.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2023-07-28 21:09+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
-"Language-Team: none\n"
+"POT-Creation-Date: 2023-09-21 06:59+0000\n"
+"PO-Revision-Date: 2023-09-21 08:59+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 3.3.1\n"
 
 #. module: account_move_update_analytic
 #: model:ir.model,name:account_move_update_analytic.model_account_move_update_analytic_wizard
@@ -81,7 +82,7 @@ msgstr "Línea de factura"
 #. module: account_move_update_analytic
 #: model:ir.model,name:account_move_update_analytic.model_account_move_line
 msgid "Journal Item"
-msgstr "Artículo diario"
+msgstr "Apunte contable"
 
 #. module: account_move_update_analytic
 #: model:ir.model.fields,field_description:account_move_update_analytic.field_account_move_update_analytic_wizard____last_update
@@ -96,7 +97,7 @@ msgstr "Actualizado por última vez por"
 #. module: account_move_update_analytic
 #: model:ir.model.fields,field_description:account_move_update_analytic.field_account_move_update_analytic_wizard__write_date
 msgid "Last Updated on"
-msgstr "última actualización el"
+msgstr "Última actualización el"
 
 #. module: account_move_update_analytic
 #: model:ir.model.fields,field_description:account_move_update_analytic.field_account_move_update_analytic_wizard__new_analytic_account_id
@@ -109,13 +110,6 @@ msgid "New Analytic Tags"
 msgstr "Nuevas etiquetas analíticas"
 
 #. module: account_move_update_analytic
-#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.account_move_form_view
-#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.account_move_line_tree_view
-#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.view_move_line_tree_grouped
-msgid "Update Analytic"
-msgstr "Actualización Analítica"
-
-#. module: account_move_update_analytic
 #: model_terms:ir.ui.view,arch_db:account_move_update_analytic.view_account_move_update_analytic_account
 msgid "Update Analytic Accounts / Tags"
 msgstr "Actualizar cuentas analíticas / etiquetas"
@@ -124,6 +118,13 @@ msgstr "Actualizar cuentas analíticas / etiquetas"
 #: model:ir.actions.act_window,name:account_move_update_analytic.action_view_account_move_update_analytic
 msgid "Update Analytic for selected Account Moves"
 msgstr "Actualización analítica para los movimientos de cuenta seleccionados"
+
+#. module: account_move_update_analytic
+#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.account_move_form_view
+#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.account_move_line_tree_view
+#: model_terms:ir.ui.view,arch_db:account_move_update_analytic.view_move_line_tree_grouped
+msgid "Update analytic account and tags"
+msgstr "Actualizar cuentas y etiquetas analíticas"
 
 #. module: account_move_update_analytic
 #: model_terms:ir.ui.view,arch_db:account_move_update_analytic.view_account_move_update_analytic_account

--- a/account_move_update_analytic/views/account_move_line_view.xml
+++ b/account_move_update_analytic/views/account_move_line_view.xml
@@ -11,10 +11,12 @@
             <field name="analytic_tag_ids" position="after">
                 <button
                     name="account_move_update_analytic.action_view_account_move_update_analytic"
-                    string="Update Analytic"
                     type="action"
                     groups="analytic.group_analytic_accounting,analytic.group_analytic_tags"
                     attrs="{'invisible': [('parent_state', '!=', 'posted')]}"
+                    icon="fa-tags"
+                    title="Update analytic account and tags"
+                    aria-label="Update analytic account and tags"
                 />
             </field>
         </field>
@@ -28,10 +30,12 @@
             <field name="analytic_tag_ids" position="after">
                 <button
                     name="account_move_update_analytic.action_view_account_move_update_analytic"
-                    string="Update Analytic"
                     type="action"
                     groups="analytic.group_analytic_accounting,analytic.group_analytic_tags"
                     attrs="{'invisible': [('parent_state', '!=', 'posted'),]}"
+                    icon="fa-tags"
+                    title="Update analytic account and tags"
+                    aria-label="Update analytic account and tags"
                 />
             </field>
         </field>

--- a/account_move_update_analytic/views/account_move_view.xml
+++ b/account_move_update_analytic/views/account_move_view.xml
@@ -16,10 +16,12 @@
                 <field name="parent_state" invisible="1" />
                 <button
                     name="account_move_update_analytic.action_view_account_move_update_analytic"
-                    string="Update Analytic"
                     type="action"
                     groups="analytic.group_analytic_accounting,analytic.group_analytic_tags"
                     attrs="{'column_invisible': [('parent.state', '!=', 'posted')]}"
+                    icon="fa-tags"
+                    title="Update analytic account and tags"
+                    aria-label="Update analytic account and tags"
                 />
             </xpath>
             <xpath
@@ -29,13 +31,15 @@
                 <field name="parent_state" invisible="1" />
                 <button
                     name="account_move_update_analytic.action_view_account_move_update_analytic"
-                    string="Update Analytic"
                     type="action"
                     groups="analytic.group_analytic_accounting,analytic.group_analytic_tags"
                     attrs="{
                         'column_invisible': [('parent.state', '!=', 'posted')],
                         'invisible': [('display_type', 'in', ('line_section', 'line_note'))],
                     }"
+                    icon="fa-tags"
+                    title="Update analytic account and tags"
+                    aria-label="Update analytic account and tags"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Button text is super large and doesn't fit well on any screen. Also is pretty ugly

Replace the button text with a pretty icon `fa-tags` and add a proper title to know what is going to happen if you click the button.
Also added maintainers

I pretend to FWP this commit into 16.0 once it's merged.

MT-3838 @moduon @yajo @rafaelbn @EmilioPascual @remi-filament plz review if you want 😄 