### PR TITLE
[13.0][IMP] purchase_analytic: avoid overwrite context in views inherited

### DIFF
--- a/purchase_analytic/__manifest__.py
+++ b/purchase_analytic/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "Acsone SA/NV, Odoo Community Association (OCA)",
     "category": "Purchase Management",
     "website": "https://github.com/OCA/account-analytic",
-    "depends": ["purchase"],
+    "depends": ["purchase", "base_view_inheritance_extension"],
     "data": ["views/purchase_views.xml"],
     "license": "AGPL-3",
     "installable": True,

--- a/purchase_analytic/views/purchase_views.xml
+++ b/purchase_analytic/views/purchase_views.xml
@@ -38,7 +38,9 @@
             <field name="order_line" position="attributes">
                 <attribute
                     name="context"
-                >{'default_account_analytic_id': project_id}</attribute>
+                    operation="python_dict"
+                    key="default_account_analytic_id"
+                >project_id</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Change the method of writing the context in the field order_line to avoid overwriting.


@ForgeFlow