### PR TITLE
[12.0][IMP] Add config setting to always use product analytic

### DIFF
--- a/product_analytic/__manifest__.py
+++ b/product_analytic/__manifest__.py
@@ -14,7 +14,9 @@
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/account-analytic',
     'depends': ['account'],
-    'data': ['views/product_view.xml'],
+    'data': ['views/product_view.xml',
+             'views/res_config_settings.xml',
+             'security/account_invoice_security.xml'],
     'demo': ['demo/product_demo.xml'],
     'installable': True,
 }

--- a/product_analytic/__manifest__.py
+++ b/product_analytic/__manifest__.py
@@ -14,9 +14,7 @@
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/account-analytic',
     'depends': ['account'],
-    'data': ['views/product_view.xml',
-             'views/res_config_settings.xml',
-             'security/account_invoice_security.xml'],
+    'data': ['views/product_view.xml'],
     'demo': ['demo/product_demo.xml'],
     'installable': True,
 }

--- a/product_analytic/__manifest__.py
+++ b/product_analytic/__manifest__.py
@@ -14,7 +14,10 @@
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/account-analytic',
     'depends': ['account'],
-    'data': ['views/product_view.xml'],
+    'data': [
+        'views/product_view.xml',
+         'security/account_invoice_security.xml',
+         ],
     'demo': ['demo/product_demo.xml'],
     'installable': True,
 }

--- a/product_analytic/models/__init__.py
+++ b/product_analytic/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import account_invoice
 from . import product
+from . import res_config_settings

--- a/product_analytic/models/__init__.py
+++ b/product_analytic/models/__init__.py
@@ -2,4 +2,3 @@
 
 from . import account_invoice
 from . import product
-from . import res_config_settings

--- a/product_analytic/models/account_invoice.py
+++ b/product_analytic/models/account_invoice.py
@@ -12,6 +12,7 @@ INV_TYPE_MAP = {
     'in_refund': 'expense',
 }
 
+GROUP_AUPAA = 'product_analytic.group_always_use_product_analytic_account'
 
 class AccountInvoiceLine(models.Model):
     _inherit = 'account.invoice.line'
@@ -31,8 +32,8 @@ class AccountInvoiceLine(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             inv_type = self.env.context.get('inv_type', 'out_invoice')
-            if vals.get('product_id') and inv_type and \
-                    not vals.get('account_analytic_id'):
+            replace_account_analytic = self.env.user.has_group(GROUP_AUPAA) or not vals.get('account_analytic_id')
+            if vals.get('product_id') and inv_type and replace_account_analytic:
                 product = self.env['product.product'].browse(
                     vals.get('product_id'))
                 ana_accounts = product.product_tmpl_id.\

--- a/product_analytic/models/res_config_settings.py
+++ b/product_analytic/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# Copyright 2016 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+from ..models.account_invoice import GROUP_AUPAA
+
+
+class AccountConfigSettings(models.TransientModel):
+
+    _inherit = 'res.config.settings'
+
+    group_always_use_product_analytic_account = fields.Boolean(
+        string="Always use product analytic account",
+        implied_group=GROUP_AUPAA)

--- a/product_analytic/readme/USAGE.rst
+++ b/product_analytic/readme/USAGE.rst
@@ -5,3 +5,5 @@ income analytic account (for customer invoice/refunds) or an expense analytic
 account (for supplier invoice/refunds) ; if it doesn't find any, it checks if
 the category of the product has an income or expense analytic account ; if an
 analytic account is found, it will be set by default on the invoice line.
+
+If you want to always set the product analytic account in the invoice lines, you can check the option Settings>Analytic>Always use product analytic account. This way, default analytic account such as the Sale Order analytic account will be overiden in the invoice lines.  

--- a/product_analytic/security/account_invoice_security.xml
+++ b/product_analytic/security/account_invoice_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="group_always_use_product_analytic_account" model="res.groups">
+        <field name="name">Always use product analytic account</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
+</odoo>

--- a/product_analytic/tests/test_account_invoice.py
+++ b/product_analytic/tests/test_account_invoice.py
@@ -15,6 +15,8 @@ class TestAccountInvoiceLine(TransactionCase):
             'name': 'test analytic_account1'})
         self.analytic_account2 = self.env['account.analytic.account'].create({
             'name': 'test analytic_account2'})
+        self.analytic_account3 = self.env['account.analytic.account'].create({
+            'name': 'test analytic_account3'})
         self.product2 = self.env['product.product'].create({
             'name': 'test product 02',
             'income_analytic_account_id': self.analytic_account1.id,
@@ -81,4 +83,44 @@ class TestAccountInvoiceLine(TransactionCase):
         invoice_line3 = self.env['account.invoice.line'].with_context(
             {'inv_type': 'out_invoice'}).create(create_data)
         self.assertEqual(invoice_line3.account_analytic_id.id,
+                         self.product2.income_analytic_account_id.id)
+
+
+    def test_create_out_with_existing_analytic_account(self):
+        # if always_use_product_analytic_account is off
+        # existing analytic account should not be overiden
+        self.env.user.groups_id -= self.env.ref(
+            "product_analytic.group_always_use_product_analytic_account"
+            )
+        create_data = {
+            'name': 'Test Line 4',
+            'quantity': 1,
+            'price_unit': 1,
+            'account_id': self.account.id,
+            'product_id': self.product2.id,
+            'account_analytic_id': self.analytic_account3.id
+        }
+        invoice_line4 = self.env['account.invoice.line'].with_context(
+            {'inv_type': 'out_invoice'}).create(create_data)
+        self.assertEqual(invoice_line4.account_analytic_id.id,
+                         self.analytic_account3.id)
+
+
+    def test_create_out_with_existing_analytic_account_force_product(self):
+        # if always_use_product_analytic_account is on
+        # existing analytic account should be overiden
+        self.env.user.groups_id += self.env.ref(
+            "product_analytic.group_always_use_product_analytic_account"
+            )
+        create_data = {
+            'name': 'Test Line 4',
+            'quantity': 1,
+            'price_unit': 1,
+            'account_id': self.account.id,
+            'product_id': self.product2.id,
+            'account_analytic_id': self.analytic_account3.id
+        }
+        invoice_line4 = self.env['account.invoice.line'].with_context(
+            {'inv_type': 'out_invoice'}).create(create_data)
+        self.assertEqual(invoice_line4.account_analytic_id.id,
                          self.product2.income_analytic_account_id.id)

--- a/product_analytic/views/res_config_settings.xml
+++ b/product_analytic/views/res_config_settings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="res_config_settings_form_view">
+        <field name="name">res.config.settings.form (in account_invoice_check_total)</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='analytic']" position="inside">
+                <div class="col-xs-12 col-md-6 o_setting_box" title="If you check this box, the system will always set the product analytic account on invoice lines.">
+                    <div class="o_setting_left_pane">
+                        <field name="group_always_use_product_analytic_account"/>
+                    </div>
+                    <div class="o_setting_right_pane" name="inv_check_total_right_pane">
+                        <label string="Always use product analytic account" for="group_always_use_product_analytic_account"/>
+                        <div class="text-muted">
+                            Always use product analytic account
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Add a configuration setting to always use the product analytic account and overide the default (for instance the sale order analytic account).

This is useful when we want to do sales reporting with analytic account based on product, instead of Sale orders. 

Ported to 16  https://github.com/OCA/account-analytic/pull/623
@robinkeunen 
  