### PR TITLE
[13.0][IMP] account_analytic_required: post-migrate column_exists

### DIFF
--- a/account_analytic_required/migrations/13.0.2.0.0/post-migrate.py
+++ b/account_analytic_required/migrations/13.0.2.0.0/post-migrate.py
@@ -7,9 +7,10 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     # Convert analytic_policy to property_analytic_policy
-    openupgrade.convert_to_company_dependent(
-        env=env,
-        model_name="account.account.type",
-        origin_field_name="analytic_policy",
-        destination_field_name="property_analytic_policy",
-    )
+    if openupgrade.column_exists(env.cr, "account_account_type", "analytic_policy"):
+        openupgrade.convert_to_company_dependent(
+            env=env,
+            model_name="account.account.type",
+            origin_field_name="analytic_policy",
+            destination_field_name="property_analytic_policy",
+        )


### PR DESCRIPTION
Added the check to run the script only when the column exists, in some cases porting from v12 to v13 if the person is already on the latest version of 12.0, the command is executed to convert analytic_required to the property_analytic_policy field [[12.0][IMP] company_dependent analytic_policy](https://github.com/OCA/account-analytic/commit/55ac585784ed1d61f832a0e087ac41942a9cc451#diff-697fca029650030cd211ec86bf4b6aef67eabb2f1d5aaa4187c75312e23873eb)

cc @marcelsavegnago @WesleyOliveira98 @rvalyi 