### PR TITLE
[16.0][FIX] account_analytic_account: set parent path unaccent=False

### DIFF
--- a/account_analytic_parent/models/account_analytic_account.py
+++ b/account_analytic_parent/models/account_analytic_account.py
@@ -17,7 +17,7 @@ class AccountAnalyticAccount(models.Model):
     _parent_store = True
     _order = "complete_name"
 
-    parent_path = fields.Char(index=True)
+    parent_path = fields.Char(index=True, unaccent=False)
     parent_id = fields.Many2one(
         string="Parent Analytic Account",
         comodel_name="account.analytic.account",


### PR DESCRIPTION
This commit avoids odoo warning:
`parent_path field on model 'account.analytic.account' should have unaccent disabled. Add 'unaccent=False' to the field definition.`