### PR TITLE
[15.0][FIX] account_analytic_parent: error when calling with NewID

### DIFF
--- a/account_analytic_parent/models/account_analytic_account.py
+++ b/account_analytic_parent/models/account_analytic_account.py
@@ -47,7 +47,7 @@ class AccountAnalyticAccount(models.Model):
         user_currency_id = self.env.user.company_id.currency_id
 
         # Re-compute only accounts with children
-        for account in self.filtered("child_ids"):
+        for account in self.exists().filtered("child_ids"):
             domain = [("account_id", "child_of", account.id)]
 
             credit_groups = AccountAnalyticLine.read_group(


### PR DESCRIPTION
This is actually an incompatibility with the module project_wbs in the project repository. The issue is when a subproject is created before saving the parent project. The compute methods in here fail when there is no actual record with given ID