### PR TITLE
[15.0][FIX] purchase_request_analytic: fill analytic account id in the purchase request

### DIFF
--- a/purchase_request_analytic/models/purchase_request.py
+++ b/purchase_request_analytic/models/purchase_request.py
@@ -26,6 +26,16 @@ class PurchaseRequest(models.Model):
         for pr in self:
             al = pr.analytic_account_id
             if pr.line_ids:
+                first_line_analytic_account_id = pr.line_ids[0].analytic_account_id
+                all_lines_same = all(
+                    prl.analytic_account_id == first_line_analytic_account_id
+                    for prl in pr.line_ids
+                )
+                # If all lines share the same analytic_account_id,
+                # set it to the purchase request.
+                if all_lines_same:
+                    pr.analytic_account_id = first_line_analytic_account_id
+                    continue
                 for prl in pr.line_ids:
                     if prl.analytic_account_id != al:
                         al = False

--- a/purchase_request_analytic/tests/test_purchase_request_analytic.py
+++ b/purchase_request_analytic/tests/test_purchase_request_analytic.py
@@ -7,8 +7,11 @@ from odoo.tests.common import TransactionCase
 class TestPurchaseRequestAnalytic(TransactionCase):
     def setUp(self):
         super(TestPurchaseRequestAnalytic, self).setUp()
-        self.anal_id = self.env["account.analytic.account"].create(
+        self.anal = self.env["account.analytic.account"].create(
             {"name": "Account Analytic for Tests"}
+        )
+        self.anal2 = self.env["account.analytic.account"].create(
+            {"name": "Account Analytic for Tests 2"}
         )
 
     def test_analytic_account(self):
@@ -35,9 +38,9 @@ class TestPurchaseRequestAnalytic(TransactionCase):
             }
         )
 
-        pr.analytic_account_id = self.anal_id.id
-        self.assertEqual(pr.analytic_account_id.id, self.anal_id.id)
-        self.assertEqual(pr.line_ids.analytic_account_id.id, self.anal_id.id)
+        pr.analytic_account_id = self.anal.id
+        self.assertEqual(pr.analytic_account_id.id, self.anal.id)
+        self.assertEqual(pr.line_ids.analytic_account_id.id, self.anal.id)
 
     def test_analytic(self):
         """Create a purchase order without line
@@ -45,6 +48,80 @@ class TestPurchaseRequestAnalytic(TransactionCase):
         Check analytic account is on purchase
         """
         pr = self.env["purchase.request"].new(
-            {"requested_by": self.env.user.id, "analytic_account_id": self.anal_id.id}
+            {"requested_by": self.env.user.id, "analytic_account_id": self.anal.id}
         )
-        self.assertEqual(pr.analytic_account_id.id, self.anal_id.id)
+        self.assertEqual(pr.analytic_account_id.id, self.anal.id)
+
+    def test_all_analytic_accounts(self):
+        """Create a purchase request with same analytic account
+        in the lines and check the purchase request has the
+        same analytic account
+        """
+        product_id = self.env.ref("product.product_product_9")
+        pr = self.env["purchase.request"].create(
+            {
+                "requested_by": self.env.user.id,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product_id.name,
+                            "product_id": product_id.id,
+                            "product_qty": 1.0,
+                            "product_uom_id": self.env.ref("uom.product_uom_unit").id,
+                            "analytic_account_id": self.anal.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product_id.name,
+                            "product_id": product_id.id,
+                            "product_qty": 1.0,
+                            "product_uom_id": self.env.ref("uom.product_uom_unit").id,
+                            "analytic_account_id": self.anal.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        self.assertEqual(pr.analytic_account_id, self.anal)
+
+    def test_not_all_analytic_accounts(self):
+        """Create a purchase request with diff analytic account
+        in the lines and check the purchase request has the
+        same analytic account
+        """
+        product_id = self.env.ref("product.product_product_9")
+        pr = self.env["purchase.request"].create(
+            {
+                "requested_by": self.env.user.id,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product_id.name,
+                            "product_id": product_id.id,
+                            "product_qty": 1.0,
+                            "product_uom_id": self.env.ref("uom.product_uom_unit").id,
+                            "analytic_account_id": self.anal.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product_id.name,
+                            "product_id": product_id.id,
+                            "product_qty": 1.0,
+                            "product_uom_id": self.env.ref("uom.product_uom_unit").id,
+                            "analytic_account_id": self.anal2.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        self.assertNotEqual(pr.analytic_account_id, self.anal)


### PR DESCRIPTION
When all the purchase request lines has the same analytic account the purchase request analytic account has to be the same.

This change fills analytic account id in the purchase request when all the lines have same analytic account id.

Before this change the analytic account is empty in those cases, and because of that, the search of purchase request by analytic account is not working

cc @ForgeFlow