### PR TITLE
[16.0][OU-ADD] account_analytic_tag: Migration scripts

### DIFF
--- a/account_analytic_tag/__init__.py
+++ b/account_analytic_tag/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import pre_init_hook

--- a/account_analytic_tag/__manifest__.py
+++ b/account_analytic_tag/__manifest__.py
@@ -19,4 +19,5 @@
     "license": "AGPL-3",
     "installable": True,
     "application": False,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/account_analytic_tag/hooks.py
+++ b/account_analytic_tag/hooks.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def pre_init_hook(cr):
+    # In case you come from a previous version, reuse the security group, and avoid
+    # to crash due to 2 groups with the same name.
+    cr.execute(
+        """UPDATE ir_model_data
+        SET module='account_analytic_tag'
+        WHERE module='analytic' and name='group_analytic_tags'
+        """
+    )


### PR DESCRIPTION
Rename the XML-ID of the security group for direct transfer and avoid crash on duplicated name.

@Tecnativa 