### PR TITLE
[14.0] account_analytic_no_lines: add migration script

### DIFF
--- a/account_analytic_no_lines/migrations/14.0.1.0.0/pre-migration.py
+++ b/account_analytic_no_lines/migrations/14.0.1.0.0/pre-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if version and version <= "10.0.1.0.0":
+        openupgrade.rename_xmlids(
+            env.cr,
+            [
+                (
+                    "account_analytic_no_lines.hide_analytic_entries",
+                    "account_analytic_no_lines.show_analytic_entries",
+                )
+            ],
+        )


### PR DESCRIPTION
The module account_analytic_no_lines has been merged in v10 and v14. Ports exists for 11/12/13, but were not merged. To avoid trouble for those who have run the module in 11/12/13, I filter the pre-migration script on version <= '10.0.1.0.0'