### PR TITLE
[16.0][FIX] stock_analytic: use standard method to get stock valuation account

### DIFF
--- a/stock_analytic/models/stock_move.py
+++ b/stock_analytic/models/stock_move.py
@@ -22,11 +22,12 @@ class StockMove(models.Model):
         )
         if not self.analytic_distribution:
             return res
+        accounts = self.product_id.product_tmpl_id.get_product_accounts()
+        account_valuation_id = (
+            accounts.get("stock_valuation") and accounts["stock_valuation"].id
+        )
         for line in res:
-            if (
-                line[2]["account_id"]
-                != self.product_id.categ_id.property_stock_valuation_account_id.id
-            ):
+            if line[2]["account_id"] != account_valuation_id:
                 # Add analytic account in debit line
                 line[2].update({"analytic_distribution": self.analytic_distribution})
         return res


### PR DESCRIPTION
This commit fixes the direct access to the value of `property_stock_valuation_account_id` defined in the product category of the product of the move.
This commit gets the account using the `get_product_accounts()` method to improve inheritability and consistency with the standard code base.