### PR TITLE
[13.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/analytic_tag_dimension_sale_warning/__manifest__.py
+++ b/analytic_tag_dimension_sale_warning/__manifest__.py
@@ -6,7 +6,7 @@
     "category": "Generic Modules/Accounting",
     "version": "13.0.1.0.0",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-analytic",
     "depends": ["analytic_tag_dimension", "sale"],
     "auto_install": True,


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 13.0.