### PR TITLE
[16.0][IMP] account_analytic_distribution_manual: Enhanced control of analytics account from manual distribution

### DIFF
--- a/account_analytic_distribution_manual/README.rst
+++ b/account_analytic_distribution_manual/README.rst
@@ -41,9 +41,6 @@ Configuration
 #. Go to Invoicing > Configuration > Analytic Accounting > Manual Analytic Distributions
 #. Create or edit the necessary records.
 
-Note: to test this module please ensure than the `account_analytic_tag_distribution` module is uninstalled, 
-This module hides the `analytic_distribution` field, 
-`see here <https://github.com/OCA/account-analytic/blob/02589b1e23041360154dd0b43ba703954b07e5f3/account_analytic_tag_distribution/views/account_move_views.xml#L11>`_
 
 Usage
 =====
@@ -52,6 +49,11 @@ Usage
 #. Open or create a invoice
 #. On the invoice line, select the analytic account. A new field labeled "Manual Distribution" should appear at the top.
 #. Select a record from the list, and it will be added to the distribution and the invoice lines.
+
+Known issues / Roadmap
+======================
+
+Compatibility with `Analytic Distribution Models` to use Manual Distribution as Default values
 
 Bug Tracker
 ===========

--- a/account_analytic_distribution_manual/__init__.py
+++ b/account_analytic_distribution_manual/__init__.py
@@ -1,3 +1,4 @@
 # Copyright 2024 Tecnativa - Carlos Lopez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import models
+from .hooks import post_init_hook

--- a/account_analytic_distribution_manual/__manifest__.py
+++ b/account_analytic_distribution_manual/__manifest__.py
@@ -23,4 +23,5 @@
         ],
     },
     "installable": True,
+    "post_init_hook": "post_init_hook",
 }

--- a/account_analytic_distribution_manual/hooks.py
+++ b/account_analytic_distribution_manual/hooks.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Tecnativa - Carlos Lopez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api, tools
+
+
+def post_init_hook(cr, registry):
+    if tools.table_exists(cr, "account_analytic_tag"):
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        sql = """
+        WITH counted_tags AS (
+            SELECT
+                tag.id,
+                tag.name,
+                tag.active,
+                tag.company_id,
+                ROW_NUMBER() OVER (PARTITION BY tag.name ORDER BY tag.id) AS row_count
+            FROM account_analytic_tag tag
+            WHERE tag.active_analytic_distribution = true
+        )
+        SELECT
+            CASE
+                WHEN row_count = 1 THEN tag.name
+                ELSE CONCAT(tag.name, ' (', tag.id, ')')
+            END AS name,
+            tag.id,
+            tag.active,
+            tag.company_id,
+            distribution.account_id,
+            distribution.percentage
+        FROM
+            counted_tags tag
+            INNER JOIN
+                account_analytic_distribution distribution ON tag.id = distribution.tag_id;
+
+        """
+        env.cr.execute(sql)
+        distribution_by_tag = {}
+        distribution_manual_vals = []
+        for data in env.cr.dictfetchall():
+            tag_key = (data["name"], data["active"], data["company_id"])
+            distribution_by_tag.setdefault(tag_key, []).append(data)
+        for tag_key, distributions in distribution_by_tag.items():
+            tag_name, tag_active, company_id = tag_key
+            distribution_manual_val = {
+                "name": tag_name,
+                "active": tag_active,
+                "company_id": company_id or env.company.id,
+                "analytic_distribution": {
+                    distribution["account_id"]: distribution["percentage"]
+                    for distribution in distributions
+                },
+            }
+            distribution_manual_vals.append(distribution_manual_val)
+        if distribution_manual_vals:
+            env["account.analytic.distribution.manual"].create(distribution_manual_vals)

--- a/account_analytic_distribution_manual/models/__init__.py
+++ b/account_analytic_distribution_manual/models/__init__.py
@@ -1,1 +1,3 @@
 from . import account_analytic_distribution_manual
+from . import analytic_mixin
+from . import base

--- a/account_analytic_distribution_manual/models/account_analytic_distribution_manual.py
+++ b/account_analytic_distribution_manual/models/account_analytic_distribution_manual.py
@@ -1,3 +1,5 @@
+# Copyright 2024 Tecnativa - Carlos Lopez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import _, api, fields, models
 
 

--- a/account_analytic_distribution_manual/models/analytic_mixin.py
+++ b/account_analytic_distribution_manual/models/analytic_mixin.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Tecnativa - Carlos Lopez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class AnalyticMixin(models.AbstractModel):
+    _inherit = "analytic.mixin"
+
+    # it will not be a many2one field
+    manual_distribution_id = fields.Integer(string="Manual Distribution ID")

--- a/account_analytic_distribution_manual/models/base.py
+++ b/account_analytic_distribution_manual/models/base.py
@@ -1,0 +1,86 @@
+# Copyright 2024 Tecnativa - Carlos Lopez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import json
+
+from lxml import etree
+
+from odoo import api, models
+from odoo.tools.misc import frozendict
+
+
+class AnalyticMixin(models.AbstractModel):
+    _inherit = "base"
+
+    @api.model
+    def get_view(self, view_id=None, view_type="form", **options):
+        """
+        The purpose of inheriting this method is to
+        add a specific field, 'manual_distribution_id',
+        to the tree/form views if the model has this field defined.
+
+        Additionally, if a one2many field exists
+        and the related model has the 'manual_distribution_id' field,
+        the method will add the 'manual_distribution_id' field to the sub-view.
+
+        Finally, the method returns the modified view.
+
+        Note: This method should be inherited in the base model,
+        not in the analytic.mixin model,
+        to ensure it executes correctly for models
+        that do not inherit from the mixin but have one2many fields.
+        For example, when rendering account.move,
+        it does not inherit from analytic.mixin,
+        but it has one2many fields that inherit from analytic.mixin.
+        """
+
+        def add_field(node, view_type, res_model):
+            attribute = "column_invisible" if view_type == "tree" else "invisible"
+            modifiers = json.dumps({attribute: True})
+            field_options = {
+                "name": manual_distribution_field_name,
+                "modifiers": modifiers,
+            }
+            field_element = etree.SubElement(node, "field", field_options)
+            new_arch, new_models = View.postprocess_and_fields(field_element, res_model)
+            _merge_view_fields(all_models, new_models)
+            return field_element
+
+        def model_has_field(model):
+            return manual_distribution_field_name in self.env[model]._fields
+
+        def _merge_view_fields(all_models, new_models):
+            """Merge new_models into all_models. Both are {modelname(str) ➔ fields(tuple)}."""
+            for model, view_fields in new_models.items():
+                if model in all_models:
+                    all_models[model] = tuple(set(all_models[model]) | set(view_fields))
+                else:
+                    all_models[model] = tuple(view_fields)
+
+        result = super().get_view(view_id=view_id, view_type=view_type, **options)
+        if view_type in ["tree", "form"]:
+            View = self.env["ir.ui.view"]
+            manual_distribution_field_name = "manual_distribution_id"
+            all_models = result["models"].copy()  # {modelname(str) ➔ fields(tuple)}
+            arch = etree.fromstring(result["arch"])
+            if model_has_field(result.get("model")):
+                root_node = arch.xpath(f"/{view_type}")
+                for node in root_node:
+                    add_field(node, view_type, result.get("model"))
+            # check fields one2many
+            for (res_model, field_list) in result["models"].items():
+                for field_name in field_list:
+                    if field_name not in self.env[res_model]._fields:
+                        continue
+                    field_def = self.env[res_model]._fields[field_name]
+                    if field_def.type != "one2many":
+                        continue
+                    if not model_has_field(field_def.comodel_name):
+                        continue
+                    for sub_view_type in ["tree", "form"]:
+                        xpath_expr = f"//field[@name='{field_name}']/{sub_view_type}"
+                        sub_node = arch.xpath(xpath_expr)
+                        for child_node in sub_node:
+                            add_field(child_node, sub_view_type, field_def.comodel_name)
+            result["arch"] = etree.tostring(arch, encoding="unicode")
+            result["models"] = frozendict(all_models)
+        return result

--- a/account_analytic_distribution_manual/readme/CONFIGURE.rst
+++ b/account_analytic_distribution_manual/readme/CONFIGURE.rst
@@ -1,6 +1,3 @@
 #. Go to Invoicing > Configuration > Analytic Accounting > Manual Analytic Distributions
 #. Create or edit the necessary records.
 
-Note: to test this module please ensure than the `account_analytic_tag_distribution` module is uninstalled, 
-This module hides the `analytic_distribution` field, 
-`see here <https://github.com/OCA/account-analytic/blob/02589b1e23041360154dd0b43ba703954b07e5f3/account_analytic_tag_distribution/views/account_move_views.xml#L11>`_

--- a/account_analytic_distribution_manual/readme/ROADMAP.rst
+++ b/account_analytic_distribution_manual/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+Compatibility with `Analytic Distribution Models` to use Manual Distribution as Default values

--- a/account_analytic_distribution_manual/static/description/index.html
+++ b/account_analytic_distribution_manual/static/description/index.html
@@ -376,11 +376,12 @@ ul.auto-toc {
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -391,9 +392,6 @@ ul.auto-toc {
 <li>Go to Invoicing &gt; Configuration &gt; Analytic Accounting &gt; Manual Analytic Distributions</li>
 <li>Create or edit the necessary records.</li>
 </ol>
-<p>Note: to test this module please ensure than the <cite>account_analytic_tag_distribution</cite> module is uninstalled,
-This module hides the <cite>analytic_distribution</cite> field,
-<a class="reference external" href="https://github.com/OCA/account-analytic/blob/02589b1e23041360154dd0b43ba703954b07e5f3/account_analytic_tag_distribution/views/account_move_views.xml#L11">see here</a></p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
@@ -404,8 +402,12 @@ This module hides the <cite>analytic_distribution</cite> field,
 <li>Select a record from the list, and it will be added to the distribution and the invoice lines.</li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
+<p>Compatibility with <cite>Analytic Distribution Models</cite> to use Manual Distribution as Default values</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-analytic/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -413,15 +415,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li>Tecnativa (<a class="reference external" href="https://www.tecnativa.com">https://www.tecnativa.com</a>):<ul>
 <li>Carlos Lopez</li>
@@ -430,7 +432,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.esm.js
+++ b/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.esm.js
@@ -2,8 +2,101 @@
 
 import {AnalyticDistribution} from "@analytic/components/analytic_distribution/analytic_distribution";
 import {patch} from "@web/core/utils/patch";
+const {useState} = owl;
 
 patch(AnalyticDistribution.prototype, "account_analytic_distribution_manual", {
+    setup() {
+        this._super();
+        this.manual_distribution_by_id = {};
+        this.state_manual_distribution = useState({
+            id: this.props.record.data.manual_distribution_id || 0,
+            label: "",
+            analytic_distribution: [],
+        });
+    },
+    async willStart() {
+        await this._super();
+        if (this.state_manual_distribution.id) {
+            this.refreshManualDistribution(this.state_manual_distribution.id);
+        }
+    },
+    async willUpdate(nextProps) {
+        await this._super(nextProps);
+        const record_id = this.props.record.data.id || 0;
+        const current_manual_distribution_id = this.state_manual_distribution.id;
+        const new_manual_distribution_id =
+            nextProps.record.data.manual_distribution_id || 0;
+        const manual_distribution_Changed =
+            current_manual_distribution_id !== new_manual_distribution_id;
+        // When record is created, and manual_distribution_id is cleared
+        // but user discard changes, we need to refresh the manual distribution
+        const force_refresh_discart = new_manual_distribution_id === 0 && record_id > 0;
+        if (
+            manual_distribution_Changed &&
+            (new_manual_distribution_id > 0 || force_refresh_discart)
+        ) {
+            await this.refreshManualDistribution(new_manual_distribution_id);
+        }
+    },
+    async save() {
+        await this._super();
+        await this.props.record.update({
+            manual_distribution_id: this.state_manual_distribution.id,
+        });
+    },
+    async refreshManualDistribution(manual_distribution_id) {
+        if (manual_distribution_id === 0) {
+            this.deleteManualTag();
+            return;
+        }
+        const current_record = this.manual_distribution_by_id[manual_distribution_id];
+        if (current_record) {
+            this.state_manual_distribution.id = current_record.id;
+            this.state_manual_distribution.label = current_record.display_name;
+            this.state_manual_distribution.analytic_distribution =
+                current_record.analytic_distribution;
+            return;
+        }
+        const records = await this.fetchAnalyticDistributionManual([
+            ["id", "=", manual_distribution_id],
+        ]);
+        if (records.length) {
+            const record = records[0];
+            this.state_manual_distribution.id = record.id;
+            this.state_manual_distribution.label = record.display_name;
+            this.state_manual_distribution.analytic_distribution =
+                record.analytic_distribution;
+        } else {
+            this.deleteManualTag();
+        }
+    },
+    get tags() {
+        let res = this._super();
+        if (this.state_manual_distribution.id) {
+            // Remove the delete button from tags
+            // it will be added only to the manual distribution tag
+            /* eslint-disable-next-line no-unused-vars */
+            res = res.map(({onDelete, ...rest}) => rest);
+            res.unshift({
+                id: this.nextId++,
+                text: this.state_manual_distribution.label,
+                onDelete: this.editingRecord ? () => this.deleteManualTag() : undefined,
+            });
+        }
+        return res;
+    },
+    deleteManualTag() {
+        this.state_manual_distribution = {
+            id: 0,
+            label: "",
+            analytic_distribution: [],
+        };
+        // Clear all distribution
+        for (const group_id in this.list) {
+            this.list[group_id].distribution = [];
+        }
+        this.autoFill();
+    },
     // Autocomplete
     sourcesAnalyticDistributionManual() {
         return [
@@ -20,11 +113,15 @@ patch(AnalyticDistribution.prototype, "account_analytic_distribution_manual", {
             [...this.searchAnalyticDistributionManualDomain(searchTerm)],
             searchLimit + 1
         );
-        const options = records.map((result) => ({
-            value: result.id,
-            label: result.display_name,
-            analytic_distribution: result.analytic_distribution,
-        }));
+        const options = [];
+        for (const record of records) {
+            options.push({
+                value: record.id,
+                label: record.display_name,
+                analytic_distribution: record.analytic_distribution,
+            });
+            this.manual_distribution_by_id[record.id] = record;
+        }
         if (!options.length) {
             options.push({
                 label: this.env._t("No Analytic Distribution Manual found"),
@@ -57,8 +154,18 @@ patch(AnalyticDistribution.prototype, "account_analytic_distribution_manual", {
         }
         return domain;
     },
+    onChangeAutoCompleteDistributionManual(inputValue) {
+        if (inputValue === "") {
+            this.deleteManualTag();
+        }
+    },
     async onSelectDistributionManual(option) {
         const selected_option = Object.getPrototypeOf(option);
+        this.state_manual_distribution = {
+            id: selected_option.value,
+            label: selected_option.label,
+            analytic_distribution: selected_option.analytic_distribution,
+        };
         const account_ids = Object.keys(selected_option.analytic_distribution).map(
             (id) => parseInt(id, 10)
         );

--- a/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.xml
+++ b/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-    <t
+   <t
         id="analytic_distribution_inherit"
         t-inherit="analytic.AnalyticDistributionPopup"
         t-inherit-mode="extension"
         owl="1"
     >
-       <xpath expr="//span[@t-if='!sortedList.length']" position="before">
+        <xpath expr="//span[@t-if='!sortedList.length']" position="before">
             <div class="pb-4 border-bottom">
                 <strong>Manual distribution</strong>
                 <AutoComplete
                     id="'analytic_manual_distribution'"
                     placeholder="'Search a Manual distribution...'"
-                    value="''"
+                    value="state_manual_distribution.label || ''"
                     sources="sourcesAnalyticDistributionManual()"
                     autoSelect="true"
                     onSelect.alike="(option) => this.onSelectDistributionManual(option)"
+                    onChange.alike="({inputValue}) => this.onChangeAutoCompleteDistributionManual(inputValue)"
                 />
             </div>
        </xpath>

--- a/account_analytic_distribution_manual/static/src/tests/tours/account_analytic_distribution_manual.esm.js
+++ b/account_analytic_distribution_manual/static/src/tests/tours/account_analytic_distribution_manual.esm.js
@@ -80,6 +80,24 @@ tour.register(
                 'div[name="invoice_line_ids"] .o_selected_row .analytic_distribution_popup input[id="analytic_manual_distribution"]',
             run: "click",
         },
+        // Compatibility with analytic_distribution_widget_remove_save
+        // this module remove buttons
+        // so to close popup click on any form area
+        {
+            content: "Close Popup",
+            trigger: "div.o_form_sheet_bg",
+            run: "click",
+        },
+        {
+            content: "Check Tag Manual is on the top",
+            trigger:
+                'div[name="invoice_line_ids"] .o_selected_row div.o_field_analytic_distribution[name="analytic_distribution"] div.o_field_tags div.o_tag_badge_text:contains("Manual Distribution 1")',
+        },
+        {
+            content: "Confirm Invoice",
+            trigger: 'button[name="action_post"]',
+            run: "click",
+        },
         // Save account.move
         ...tour.stepUtils.saveForm(),
     ]

--- a/account_analytic_distribution_manual/tests/test_analytic_distribution_manual_tour.py
+++ b/account_analytic_distribution_manual/tests/test_analytic_distribution_manual_tour.py
@@ -31,7 +31,6 @@ class TestAnalyticDistributionManual(DistributionManualCommon, HttpCase):
                 login="analytic-manual-distribution-user",
             )
         invoice = capt.records
-        invoice.action_post()
         self.assertEqual(invoice.partner_id, self.partner_a)
         self.assertEqual(len(invoice.invoice_line_ids.analytic_line_ids), 2)
         analytic_line1 = invoice.invoice_line_ids.analytic_line_ids.filtered(


### PR DESCRIPTION
- Show the current distribution selected at the top of the tags
- When unselecting a distribution, all related analytic accounts are also unselected
- post_init_hook to convert old data to new models(if table exists)

@Tecnativa TT50235 
@carolinafernandez-tecnativa @pedrobaeza could you please take a look

![image](https://github.com/user-attachments/assets/c0deb575-e3ad-4d47-b62a-f254984dda7e)
