### PR TITLE
[16.0][FIX] product_analytic: analytic distribution compute

### DIFF
--- a/product_analytic/models/account_move.py
+++ b/product_analytic/models/account_move.py
@@ -26,7 +26,12 @@ class AccountMoveLine(models.Model):
             return res
         for line in self:
             inv_type = line.move_id.move_type
-            if line.product_id and inv_type and inv_type != "entry":
+            if (
+                line.product_id
+                and not line.analytic_distribution
+                and inv_type
+                and inv_type != "entry"
+            ):
                 ana_accounts = (
                     line.product_id.product_tmpl_id._get_product_analytic_accounts()
                 )


### PR DESCRIPTION
When the inverse product compute method is triggered, the current analytic distribution is removed, for example, if you modify the default distribution for an invoice line and duplicate the invoice.