### PR TITLE
[16.0][IMP] account_analytic_distribution_manual: change field type from integer to many2one

### DIFF
--- a/account_analytic_distribution_manual/hooks.py
+++ b/account_analytic_distribution_manual/hooks.py
@@ -3,10 +3,112 @@
 
 from odoo import SUPERUSER_ID, api, tools
 
+# metadata for all models related to account_analytic_tag(m2m)
+# add more models if needed
+RELATION_M2M_INFO = {
+    "account_analytic_tag_account_asset_profile_rel": {
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+        "table2": "account_asset_profile",
+        "column2": "account_asset_profile_id",
+    },
+    "account_analytic_tag_hr_expense_rel": {
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+        "table2": "hr_expense",
+        "column2": "hr_expense_id",
+    },
+    "account_reconcile_model_second_analytic_tag_rel": {
+        "table2": "account_reconcile_model",
+        "column2": "account_reconcile_model_id",
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+    },
+    "hr_timesheet_switch_line_tag_rel": {
+        "table2": "hr_timesheet_switch",
+        "column2": "line_id",
+        "table1": "account_analytic_tag",
+        "column1": "tag_id",
+    },
+    "account_analytic_tag_sale_order_line_rel": {
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+        "table2": "sale_order_line",
+        "column2": "sale_order_line_id",
+    },
+    "account_reconcile_model_analytic_tag_rel": {
+        "table2": "account_reconcile_model_line",
+        "column2": "account_reconcile_model_line_id",
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+    },
+    "account_analytic_tag_mis_report_instance_rel": {
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+        "table2": "mis_report_instance",
+        "column2": "mis_report_instance_id",
+    },
+    "account_analytic_tag_account_move_line_rel": {
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+        "table2": "account_move_line",
+        "column2": "account_move_line_id",
+    },
+    "account_analytic_tag_mis_report_instance_period_rel": {
+        "table2": "mis_report_instance_period",
+        "column2": "mis_report_instance_period_id",
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+    },
+    "account_analytic_tag_general_ledger_report_wizard_rel": {
+        "table2": "general_ledger_report_wizard",
+        "column2": "general_ledger_report_wizard_id",
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+    },
+    "account_analytic_default_account_analytic_tag_rel": {
+        "table2": "account_analytic_default",
+        "column2": "account_analytic_default_id",
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+    },
+    "account_analytic_tag_purchase_order_line_rel": {
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+        "table2": "purchase_order_line",
+        "column2": "purchase_order_line_id",
+    },
+    "account_analytic_tag_account_asset_rel": {
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+        "table2": "account_asset",
+        "column2": "account_asset_id",
+    },
+    "account_analytic_tag_project_task_stock_rel": {
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+        "table2": "project_task",
+        "column2": "project_task_id",
+    },
+    "account_analytic_tag_project_task_rel": {
+        "table1": "account_analytic_tag",
+        "column1": "account_analytic_tag_id",
+        "table2": "project_task",
+        "column2": "project_task_id",
+    },
+    "account_analytic_line_tag_rel": {
+        "table2": "account_analytic_line",
+        "column2": "line_id",
+        "table1": "account_analytic_tag",
+        "column1": "tag_id",
+    },
+}
+
 
 def post_init_hook(cr, registry):
     if tools.table_exists(cr, "account_analytic_tag"):
         env = api.Environment(cr, SUPERUSER_ID, {})
+        DistributionManual = env["account.analytic.distribution.manual"]
         sql = """
         WITH counted_tags AS (
             SELECT
@@ -36,12 +138,13 @@ def post_init_hook(cr, registry):
         """
         env.cr.execute(sql)
         distribution_by_tag = {}
-        distribution_manual_vals = []
         for data in env.cr.dictfetchall():
-            tag_key = (data["name"], data["active"], data["company_id"])
+            tag_key = (data["id"], data["name"], data["active"], data["company_id"])
             distribution_by_tag.setdefault(tag_key, []).append(data)
+        distribution_map = {}
+        all_tag_ids = []
         for tag_key, distributions in distribution_by_tag.items():
-            tag_name, tag_active, company_id = tag_key
+            tag_id, tag_name, tag_active, company_id = tag_key
             distribution_manual_val = {
                 "name": tag_name,
                 "active": tag_active,
@@ -51,6 +154,31 @@ def post_init_hook(cr, registry):
                     for distribution in distributions
                 },
             }
-            distribution_manual_vals.append(distribution_manual_val)
-        if distribution_manual_vals:
-            env["account.analytic.distribution.manual"].create(distribution_manual_vals)
+            new_distribution = DistributionManual.create(distribution_manual_val)
+            distribution_map[tag_id] = new_distribution
+            all_tag_ids.append(tag_id)
+        # Update references in all models related to account_analytic_tag(m2m)
+        for table_m2m, info in RELATION_M2M_INFO.items():
+            column1 = info["column1"]
+            table2 = info["table2"]
+            column2 = info["column2"]
+            res_model_name = table2.replace("_", ".")
+            if (
+                res_model_name in env
+                and "manual_distribution_id" in env[res_model_name]._fields
+            ):
+                sql = f"""
+                SELECT {column1}, {column2}
+                FROM {table_m2m}
+                WHERE {column1} IN %s
+                """
+                env.cr.execute(sql, (tuple(all_tag_ids),))
+                for tag_id, res_id in env.cr.fetchall():
+                    env.cr.execute(
+                        f"""
+                        UPDATE {table2}
+                        SET manual_distribution_id = %s
+                        WHERE id = %s
+                        """,
+                        (distribution_map[tag_id].id, res_id),
+                    )

--- a/account_analytic_distribution_manual/models/analytic_mixin.py
+++ b/account_analytic_distribution_manual/models/analytic_mixin.py
@@ -6,5 +6,4 @@ from odoo import fields, models
 class AnalyticMixin(models.AbstractModel):
     _inherit = "analytic.mixin"
 
-    # it will not be a many2one field
-    manual_distribution_id = fields.Integer(string="Manual Distribution ID")
+    manual_distribution_id = fields.Many2one("account.analytic.distribution.manual")

--- a/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.esm.js
+++ b/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.esm.js
@@ -9,7 +9,9 @@ patch(AnalyticDistribution.prototype, "account_analytic_distribution_manual", {
         this._super();
         this.manual_distribution_by_id = {};
         this.state_manual_distribution = useState({
-            id: this.props.record.data.manual_distribution_id || 0,
+            id: this.props.record.data.manual_distribution_id
+                ? this.props.record.data.manual_distribution_id[0]
+                : 0,
             label: "",
             analytic_distribution: [],
         });
@@ -24,8 +26,9 @@ patch(AnalyticDistribution.prototype, "account_analytic_distribution_manual", {
         await this._super(nextProps);
         const record_id = this.props.record.data.id || 0;
         const current_manual_distribution_id = this.state_manual_distribution.id;
-        const new_manual_distribution_id =
-            nextProps.record.data.manual_distribution_id || 0;
+        const new_manual_distribution_id = nextProps.record.data.manual_distribution_id
+            ? this.props.record.data.manual_distribution_id[0]
+            : 0;
         const manual_distribution_Changed =
             current_manual_distribution_id !== new_manual_distribution_id;
         // When record is created, and manual_distribution_id is cleared
@@ -41,7 +44,10 @@ patch(AnalyticDistribution.prototype, "account_analytic_distribution_manual", {
     async save() {
         await this._super();
         await this.props.record.update({
-            manual_distribution_id: this.state_manual_distribution.id,
+            manual_distribution_id: [
+                this.state_manual_distribution.id,
+                this.state_manual_distribution.label,
+            ],
         });
     },
     async refreshManualDistribution(manual_distribution_id) {


### PR DESCRIPTION
- If the user needs to group by this field, it was impossible when it was an integer.
- Added a script to populate the new field in models related to account_analytic_tags. 
Note: When multiple tags are present, only the last record is populated.

@Tecnativa TT50235

@carolinafernandez-tecnativa  @pedrobaeza could you please review these changes?