### PR TITLE
[16.0][FIX] account_analytic_required: remove unneeded dependency

### DIFF
--- a/account_analytic_required/__manifest__.py
+++ b/account_analytic_required/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-analytic",
-    "depends": ["account_usability"],
+    "depends": ["account"],
     "data": ["views/account_account_views.xml"],
     "installable": True,
 }


### PR DESCRIPTION
The dependency on `account_usability` is not required to install the module, ~and let it do it's validation purpose.~

~To configure it, Odoo EE users don't need anything else. In CE, accounting users install account_usability anyway.~

~So this commit makes it compatible with both editions.~

nor to configure it