### PR TITLE
[14.0][IMP] stock_picking_analytic: add picking analytic account in invoice

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
 # See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca_dependencies-txt
+account-invoicing

--- a/stock_picking_analytic/README.rst
+++ b/stock_picking_analytic/README.rst
@@ -58,6 +58,7 @@ Contributors
 
 * Benoît Aimont <benoit.aimont@acsone.eu>
 * Denis Roussel <denis.roussel@acsone.eu>
+* Wesley Oliveira <wesley.oliveira@escodoo.com.br>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_picking_analytic/__manifest__.py
+++ b/stock_picking_analytic/__manifest__.py
@@ -11,6 +11,7 @@
     "website": "https://github.com/OCA/account-analytic",
     "depends": [
         "stock_analytic",
+        "stock_picking_invoicing",
         "base_view_inheritance_extension",
     ],
     "data": [

--- a/stock_picking_analytic/models/__init__.py
+++ b/stock_picking_analytic/models/__init__.py
@@ -1,1 +1,2 @@
 from . import stock_picking
+from . import stock_invoice_onshipping

--- a/stock_picking_analytic/models/stock_invoice_onshipping.py
+++ b/stock_picking_analytic/models/stock_invoice_onshipping.py
@@ -1,0 +1,21 @@
+# Copyright 2024 - TODAY, Wesley Oliveira <wesley.oliveira@escodoo.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockInvoiceOnshipping(models.TransientModel):
+
+    _inherit = "stock.invoice.onshipping"
+
+    def _get_invoice_line_values(self, moves, invoice_values, invoice):
+        """
+        Include the analytic account filled in picking when creating an invoice
+        """
+        values = super(StockInvoiceOnshipping, self)._get_invoice_line_values(
+            moves, invoice_values, invoice
+        )
+        move = fields.first(moves)
+        if move.analytic_account_id:
+            values["analytic_account_id"] = move.analytic_account_id
+        return values

--- a/stock_picking_analytic/readme/CONTRIBUTORS.rst
+++ b/stock_picking_analytic/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Benoît Aimont <benoit.aimont@acsone.eu>
 * Denis Roussel <denis.roussel@acsone.eu>
+* Wesley Oliveira <wesley.oliveira@escodoo.com.br>

--- a/stock_picking_analytic/static/description/index.html
+++ b/stock_picking_analytic/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -404,12 +404,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Benoît Aimont &lt;<a class="reference external" href="mailto:benoit.aimont&#64;acsone.eu">benoit.aimont&#64;acsone.eu</a>&gt;</li>
 <li>Denis Roussel &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</li>
+<li>Wesley Oliveira &lt;<a class="reference external" href="mailto:wesley.oliveira&#64;escodoo.com.br">wesley.oliveira&#64;escodoo.com.br</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/stock_picking_analytic/tests/__init__.py
+++ b/stock_picking_analytic/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_picking_analytic_account
+from . import test_stock_invoice_onshipping

--- a/stock_picking_analytic/tests/test_stock_invoice_onshipping.py
+++ b/stock_picking_analytic/tests/test_stock_invoice_onshipping.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2019-Today: Odoo Community Association (OCA)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import SavepointCase
+
+
+class TestStockInvoiceOnshipping(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestStockInvoiceOnshipping, cls).setUpClass()
+        cls.picking_model = cls.env["stock.picking"]
+        cls.move_model = cls.env["stock.move"]
+        cls.invoice_wizard = cls.env["stock.invoice.onshipping"]
+        cls.invoice_model = cls.env["account.move"]
+        cls.analytic_account_model = cls.env["account.analytic.account"]
+
+        cls.partner = cls.env.ref("base.res_partner_2")
+        cls.pick_type_out = cls.env.ref("stock.picking_type_out")
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.customers_location = cls.env.ref("stock.stock_location_customers")
+        cls.product = cls.env.ref("product.product_product_9")
+
+        cls.analytic_account = cls.analytic_account_model.create(
+            {
+                "name": "Test Analytic Account",
+            }
+        )
+
+    def test_get_invoice_line_values(self):
+        picking = self.picking_model.create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.pick_type_out.id,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customers_location.id,
+                "analytic_account_id": self.analytic_account.id,
+            }
+        )
+        move_vals = {
+            "product_id": self.product.id,
+            "picking_id": picking.id,
+            "location_dest_id": self.customers_location.id,
+            "location_id": self.stock_location.id,
+            "name": self.product.name,
+            "product_uom_qty": 2,
+            "product_uom": self.product.uom_id.id,
+            "analytic_account_id": self.analytic_account.id,
+        }
+        new_move = self.move_model.create(move_vals)
+        new_move.onchange_product_id()
+        picking.set_to_be_invoiced()
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking.button_validate()
+        wizard_obj = self.invoice_wizard.with_context(
+            active_ids=picking.ids,
+            active_model=picking._name,
+            active_id=picking.id,
+        )
+        fields_list = wizard_obj.fields_get().keys()
+        wizard_values = wizard_obj.default_get(fields_list)
+        wizard = wizard_obj.create(wizard_values)
+        wizard.onchange_group()
+        wizard.action_generate()
+        domain = [("picking_ids", "=", picking.id)]
+        invoice = self.invoice_model.search(domain)
+
+        for invoice_line in invoice.invoice_line_ids:
+            self.assertEqual(
+                invoice_line.analytic_account_id.id,
+                picking.analytic_account_id.id,
+            )


### PR DESCRIPTION
In `account-invoicing` repository we have the module [stock_picking_invoicing](https://github.com/OCA/account-invoicing/tree/14.0/stock_picking_invoicing), witch doesnt send the analytic account filled in the picking when create an invoice from the picking, so this pull request propose to insert the analytic account inside the account move line.

Set analytic account in the picking
![image](https://github.com/user-attachments/assets/ea3d58dc-a393-4e38-9420-bc470f48b1a7)

When create an invoice, the move lines have the same analytic account as picking
![image](https://github.com/user-attachments/assets/432a0e43-6c5d-4426-9729-7848a67c88f4)

Ticket: HT00845

cc: @marcelsavegnago @kaynnan @douglascstd 