### PR TITLE
[FIX] account_analytic_required: make field non-company-dependant

### DIFF
--- a/account_analytic_required/README.rst
+++ b/account_analytic_required/README.rst
@@ -29,7 +29,7 @@ Account Analytic Required
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module adds an option *analytic policy* on accounts.
-You have the choice between 4 policies : *always*, *never*, *posted moves* and *optional*.
+You have the choice between 4 policies : *always*, *never*, *posted moves* and empty (*optional*).
 
 **Table of contents**
 
@@ -79,6 +79,7 @@ Contributors
 * `Trobz <https://trobz.com>`_:
 
     * Nguyễn Minh Chiến <chien@trobz.com>
+* Jairo Llopis (`Moduon <https://www.moduon.team/>`__)
 
 Other credits
 ~~~~~~~~~~~~~

--- a/account_analytic_required/__manifest__.py
+++ b/account_analytic_required/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 {
     "name": "Account Analytic Required",
-    "version": "16.0.1.0.1",
+    "version": "16.0.2.0.0",
     "category": "Analytic Accounting",
     "license": "AGPL-3",
     "author": "Akretion, Odoo Community Association (OCA)",

--- a/account_analytic_required/migrations/16.0.2.0.0/post-migrate.py
+++ b/account_analytic_required/migrations/16.0.2.0.0/post-migrate.py
@@ -1,0 +1,32 @@
+# Copyright 2024 Moduon Team S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+"""Convert company-dependant field to normal."""
+
+
+def migrate(cr, version):
+    cr.execute(
+        r"""
+        UPDATE account_account AS acc
+        SET analytic_policy = prop.value_text
+        FROM (
+            SELECT
+                substring(res_id FROM '\d+')::int AS account_id,
+                value_text
+            FROM ir_property
+            WHERE
+                name = 'analytic_policy'
+                AND res_id LIKE 'account.account,%'
+                AND value_text != 'optional'
+        ) AS prop
+        WHERE
+            acc.id = prop.account_id
+        """
+    )
+    cr.execute(
+        """
+        DELETE FROM ir_property
+        WHERE
+            name = 'analytic_policy'
+            AND res_id LIKE 'account.account,%'
+        """
+    )

--- a/account_analytic_required/models/account.py
+++ b/account_analytic_required/models/account.py
@@ -11,26 +11,22 @@ class AccountAccount(models.Model):
 
     analytic_policy = fields.Selection(
         selection=[
-            ("optional", "Optional"),
             ("always", "Always"),
             ("posted", "Posted moves"),
             ("never", "Never"),
         ],
         string="Policy for analytic account",
-        default="optional",
-        company_dependent=True,
         help=(
             "Sets the policy for analytic accounts.\n"
             "If you select:\n"
-            "- Optional: The accountant is free to put an analytic account "
+            "- Empty: The accountant is free to put an analytic account "
             "on an account move line with this type of account.\n"
             "- Always: The accountant will get an error message if "
             "there is no analytic account.\n"
             "- Posted moves: The accountant will get an error message if no "
             "analytic account is defined when the move is posted.\n"
             "- Never: The accountant will get an error message if an analytic "
-            "account is present.\n\n"
-            "This field is company dependent."
+            "account is present."
         ),
     )
 

--- a/account_analytic_required/readme/CONTRIBUTORS.rst
+++ b/account_analytic_required/readme/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@
 * `Trobz <https://trobz.com>`_:
 
     * Nguyễn Minh Chiến <chien@trobz.com>
+* Jairo Llopis (`Moduon <https://www.moduon.team/>`__)

--- a/account_analytic_required/readme/DESCRIPTION.rst
+++ b/account_analytic_required/readme/DESCRIPTION.rst
@@ -1,2 +1,2 @@
 This module adds an option *analytic policy* on accounts.
-You have the choice between 4 policies : *always*, *never*, *posted moves* and *optional*.
+You have the choice between 4 policies : *always*, *never*, *posted moves* and empty (*optional*).

--- a/account_analytic_required/static/description/index.html
+++ b/account_analytic_required/static/description/index.html
@@ -371,7 +371,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/account-analytic/tree/16.0/account_analytic_required"><img alt="OCA/account-analytic" src="https://img.shields.io/badge/github-OCA%2Faccount--analytic-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/account-analytic-16-0/account-analytic-16-0-account_analytic_required"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/account-analytic&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module adds an option <em>analytic policy</em> on accounts.
-You have the choice between 4 policies : <em>always</em>, <em>never</em>, <em>posted moves</em> and <em>optional</em>.</p>
+You have the choice between 4 policies : <em>always</em>, <em>never</em>, <em>posted moves</em> and empty (<em>optional</em>).</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -437,6 +437,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Nguyễn Minh Chiến &lt;<a class="reference external" href="mailto:chien&#64;trobz.com">chien&#64;trobz.com</a>&gt;</li>
 </ul>
 </blockquote>
+</li>
+<li><p class="first">Jairo Llopis (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</p>
 </li>
 </ul>
 </div>

--- a/account_analytic_required/tests/test_account_analytic_required.py
+++ b/account_analytic_required/tests/test_account_analytic_required.py
@@ -93,7 +93,7 @@ class TestAccountAnalyticRequired(common.TransactionCase):
         account.analytic_policy = policy
 
     def test_optional(self):
-        self._set_analytic_policy("optional")
+        self._set_analytic_policy(False)
         self._create_move(with_analytic=False)
         self._create_move(with_analytic=True)
 


### PR DESCRIPTION
The model `account.account` is already company-dependant by itself. Thus, adding a company-dependant field makes no sense.

@moduon MT-7319