### PR TITLE
[14.0][IMP] analytic_activity_based_cost: improve analytic line view

### DIFF
--- a/analytic_activity_based_cost/views/account_analytic_line.xml
+++ b/analytic_activity_based_cost/views/account_analytic_line.xml
@@ -35,6 +35,10 @@
         />
         <field name="arch" type="xml">
 
+            <xpath expr="//group[not(@name) and not(node())]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
             <group name="amount" position="after">
                 <group
                     name="activity_cost"
@@ -43,27 +47,37 @@
                 >
                     <field name="unit_abcost" />
                     <field name="amount_abcost" />
-                    <field
-                        name="parent_id"
-                        readonly="True"
-                        attrs="{'invisible': ('parent_id', '=', False)}"
-                    />
-                    <field
-                        name="child_ids"
-                        readonly="True"
-                        attrs="{'invisible': ('child_ids', '=', False)}"
-                    >
-                        <tree name="child_ids_tree">
-                            <field name="name" />
-                            <field name="unit_amount" />
-                            <field name="amount" />
-                            <field name="unit_abcost" />
-                            <field name="amount_abcost" />
-                        </tree>
-                    </field>
                 </group>
             </group>
 
+            <sheet position="inside">
+                <notebook
+                    attrs="{'invisible': [('parent_id', '=', False),('child_ids', '=', [])]}"
+                >
+                    <page string="Related Analytic Items">
+                        <group>
+                            <field
+                                name="parent_id"
+                                readonly="True"
+                                attrs="{'invisible': [('parent_id', '=', False)]}"
+                            />
+                            <field
+                                name="child_ids"
+                                readonly="True"
+                                attrs="{'invisible': [('child_ids', '=', [])]}"
+                            >
+                                <tree name="child_ids_tree">
+                                    <field name="name" />
+                                    <field name="unit_amount" />
+                                    <field name="amount" />
+                                    <field name="unit_abcost" />
+                                    <field name="amount_abcost" />
+                                </tree>
+                            </field>
+                        </group>
+                    </page>
+                </notebook>
+            </sheet>
         </field>
     </record>
 


### PR DESCRIPTION
- [X] Make this empty group [account_analytic_view.xml](https://github.com/odoo/odoo/blob/14.0/addons/account/views/account_analytic_view.xml#L18) invisible to adjust the form view.
- [X] Fix invisible attribute for `parent_id` and `child_ids`.
- [X] Move `parent_id` and `child_ids` to a notebook for more space.

Before:
![image](https://github.com/user-attachments/assets/32ac7da0-62f7-4a32-a602-89d42d185506)

After:
No parent and no childs
![image](https://github.com/user-attachments/assets/582e46d6-c645-4283-8903-934ac56cde19)

With parent
![image](https://github.com/user-attachments/assets/c4240a1a-d6c1-4584-85d5-ec02aacc04e5)

With childs
![image](https://github.com/user-attachments/assets/c21a0714-14ff-4983-8b72-3b0bca44a0a5)

cc: @marcelsavegnago @kaynnan @douglascstd