### PR TITLE
[16.0][IMP] account_analytic_organization: Added company_id field and fixed spanish translation

### DIFF
--- a/account_analytic_organization/README.rst
+++ b/account_analytic_organization/README.rst
@@ -85,6 +85,14 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-mpascuall| image:: https://github.com/mpascuall.png?size=40px
+    :target: https://github.com/mpascuall
+    :alt: mpascuall
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-mpascuall| 
+
 This module is part of the `OCA/account-analytic <https://github.com/OCA/account-analytic/tree/16.0/account_analytic_organization>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/account_analytic_organization/__manifest__.py
+++ b/account_analytic_organization/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 APSL - Nagarro
+# Copyright 2024 APSL - Nagarro
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Analytic Organization",
@@ -17,4 +17,5 @@
         "views/account_analytic_organization.xml",
     ],
     "installable": True,
+    "maintainers": ["mpascuall"],
 }

--- a/account_analytic_organization/i18n/ca.po
+++ b/account_analytic_organization/i18n/ca.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-18 11:09+0000\n"
-"PO-Revision-Date: 2024-09-18 11:09+0000\n"
+"POT-Creation-Date: 2024-10-07 10:40+0000\n"
+"PO-Revision-Date: 2024-10-07 10:40+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -20,7 +19,7 @@ msgstr ""
 #: model:ir.actions.act_window,name:account_analytic_organization.account_analytic_organization_action
 #: model:ir.model,name:account_analytic_organization.model_account_analytic_organization
 msgid "Account Analytic Organization"
-msgstr ""
+msgstr "Organització Analítica"
 
 #. module: account_analytic_organization
 #: model:ir.model,name:account_analytic_organization.model_account_analytic_line
@@ -37,6 +36,11 @@ msgstr "Línia analítica"
 #: model_terms:ir.ui.view,arch_db:account_analytic_organization.view_account_move_line_search_inherit
 msgid "Analytic Organization"
 msgstr "Organització Analítica"
+
+#. module: account_analytic_organization
+#: model:ir.model.fields,field_description:account_analytic_organization.field_account_analytic_organization__company_id
+msgid "Company"
+msgstr "Empresa"
 
 #. module: account_analytic_organization
 #: model:ir.model,name:account_analytic_organization.model_res_partner
@@ -88,5 +92,7 @@ msgstr "Darrera Actualització el"
 msgid "Name"
 msgstr "Nom"
 
-#~ msgid "Old"
-#~ msgstr "Antic"
+#. module: account_analytic_organization
+#: model:ir.model.fields,field_description:account_analytic_organization.field_account_analytic_organization__old_id
+msgid "Old"
+msgstr "Antiga"

--- a/account_analytic_organization/i18n/es.po
+++ b/account_analytic_organization/i18n/es.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-18 11:11+0000\n"
-"PO-Revision-Date: 2024-09-18 11:11+0000\n"
+"POT-Creation-Date: 2024-10-07 10:41+0000\n"
+"PO-Revision-Date: 2024-10-07 10:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -20,7 +19,7 @@ msgstr ""
 #: model:ir.actions.act_window,name:account_analytic_organization.account_analytic_organization_action
 #: model:ir.model,name:account_analytic_organization.model_account_analytic_organization
 msgid "Account Analytic Organization"
-msgstr ""
+msgstr "Organización Analítica"
 
 #. module: account_analytic_organization
 #: model:ir.model,name:account_analytic_organization.model_account_analytic_line
@@ -36,7 +35,12 @@ msgstr "Línea analítica"
 #: model_terms:ir.ui.view,arch_db:account_analytic_organization.view_account_analytic_line_search_inherit
 #: model_terms:ir.ui.view,arch_db:account_analytic_organization.view_account_move_line_search_inherit
 msgid "Analytic Organization"
-msgstr "Organitzación Analítica"
+msgstr "Organización Analítica"
+
+#. module: account_analytic_organization
+#: model:ir.model.fields,field_description:account_analytic_organization.field_account_analytic_organization__company_id
+msgid "Company"
+msgstr "Empresa"
 
 #. module: account_analytic_organization
 #: model:ir.model,name:account_analytic_organization.model_res_partner
@@ -88,5 +92,7 @@ msgstr "Última Actualización el"
 msgid "Name"
 msgstr "Nombre"
 
-#~ msgid "Old"
-#~ msgstr "Antiguo"
+#. module: account_analytic_organization
+#: model:ir.model.fields,field_description:account_analytic_organization.field_account_analytic_organization__old_id
+msgid "Old"
+msgstr "Antigua"

--- a/account_analytic_organization/models/__init__.py
+++ b/account_analytic_organization/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 APSL - Nagarro
+# Copyright 2024 APSL - Nagarro
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import res_partner

--- a/account_analytic_organization/models/account_analytic_line.py
+++ b/account_analytic_organization/models/account_analytic_line.py
@@ -1,4 +1,4 @@
-# Copyright 2023 APSL - Nagarro
+# Copyright 2024 APSL - Nagarro
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models

--- a/account_analytic_organization/models/account_analytic_organization.py
+++ b/account_analytic_organization/models/account_analytic_organization.py
@@ -1,4 +1,4 @@
-# Copyright 2023 APSL - Nagarro
+# Copyright 2024 APSL - Nagarro
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -9,3 +9,6 @@ class AccountAnalyticOrganization(models.Model):
     _description = "Account Analytic Organization"
 
     name = fields.Char(required=True)
+    company_id = fields.Many2one(
+        "res.company", string="Company", default=lambda self: self.env.company
+    )

--- a/account_analytic_organization/models/account_move_line.py
+++ b/account_analytic_organization/models/account_move_line.py
@@ -1,4 +1,4 @@
-# Copyright 2023 APSL - Nagarro
+# Copyright 2024 APSL - Nagarro
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models

--- a/account_analytic_organization/models/res_partner.py
+++ b/account_analytic_organization/models/res_partner.py
@@ -1,4 +1,4 @@
-# Copyright 2023 APSL - Nagarro
+# Copyright 2024 APSL - Nagarro
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -8,5 +8,21 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     analytic_org_id = fields.Many2one(
-        "account.analytic.organization", string="Analytic Organization"
+        "account.analytic.organization",
+        string="Analytic Organization",
+        domain=lambda self: [("company_id", "=", self.env.company.id)],
     )
+
+    def name_get(self):
+        result = super(ResPartner, self).name_get()
+        updated_result = []
+
+        for partner_id, name in result:
+            partner = self.browse(partner_id)
+            if partner.analytic_org_id:
+                name = f"{partner.name} ({partner.analytic_org_id.name})"
+            else:
+                name = partner.name or ""
+            updated_result.append((partner_id, name))
+
+        return updated_result

--- a/account_analytic_organization/static/description/index.html
+++ b/account_analytic_organization/static/description/index.html
@@ -429,6 +429,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/mpascuall"><img alt="mpascuall" src="https://github.com/mpascuall.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/account-analytic/tree/16.0/account_analytic_organization">OCA/account-analytic</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/account_analytic_organization/views/account_analytic_organization.xml
+++ b/account_analytic_organization/views/account_analytic_organization.xml
@@ -3,8 +3,9 @@
     <field name="name">account.analytic.organization.tree</field>
     <field name="model">account.analytic.organization</field>
     <field name="arch" type="xml">
-        <tree editable="top">  <!-- O editable="top" -->
+        <tree editable="top">
             <field name="name" />
+            <field name="company_id" />
         </tree>
     </field>
     </record>
@@ -14,6 +15,7 @@
         <field name="res_model">account.analytic.organization</field>
         <field name="view_mode">tree</field>
         <field name="view_id" ref="view_account_analytic_organization_tree" />
+        <field name="domain">[('company_id','=',allowed_company_ids[0])]</field>
     </record>
 
     <menuitem


### PR DESCRIPTION
On this improvement i added the company_id field to make it work better with multi-company option and fixed spanish translation. I also inherited get_name method in order to show the organization name in the partner name.
cc https://github.com/APSL 160524

@miquelalzanillas @lbarry-apsl @javierobcn @peluko00 @BernatObrador @ppyczko please review