### PR TITLE
[16.0][IMP] account_move_update_analytic: suppress invoice sync

### DIFF
--- a/account_move_update_analytic/wizards/account_move_update_analytic.py
+++ b/account_move_update_analytic/wizards/account_move_update_analytic.py
@@ -40,4 +40,6 @@ class AccountMoveUpdateAnalytic(models.TransientModel):
 
     def update_analytic_lines(self):
         self.ensure_one()
-        self.line_id.analytic_distribution = self.analytic_distribution
+        self.line_id.with_context(
+            skip_invoice_sync=True
+        ).analytic_distribution = self.analytic_distribution


### PR DESCRIPTION
depending on the set of modules installed, updating the analytic account might trigger a call to `_sync_dynamic_lines` which we don't want here