### PR TITLE
[18.0][IMP] account_analytic_tag: Add analytic tags field to journal items tree view

### DIFF
--- a/account_analytic_tag/__manifest__.py
+++ b/account_analytic_tag/__manifest__.py
@@ -13,6 +13,7 @@
         "security/ir.model.access.csv",
         "views/account_analytic_line_views.xml",
         "views/account_analytic_tag_views.xml",
+        "views/account_move_line_views.xml",
         "views/account_move_views.xml",
         "views/res_config_settings_views.xml",
     ],

--- a/account_analytic_tag/views/account_move_line_views.xml
+++ b/account_analytic_tag/views/account_move_line_views.xml
@@ -1,0 +1,18 @@
+<odoo>
+    <record id="view_move_line_tree" model="ir.ui.view">
+        <field name="name">account.move.line.tree</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_tree" />
+        <field name="arch" type="xml">
+            <field name="analytic_distribution" position="after">
+                <field
+                    name="analytic_tag_ids"
+                    groups="account_analytic_tag.group_analytic_tags"
+                    optional="hide"
+                    widget="many2many_tags"
+                    options="{'color_field': 'color'}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/account-analytic/pull/718

Add analytic tags field to journal items tree view

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT51992