### PR TITLE
[17.0][FIX] account_analytic_tag: Add analytic tags to taxes with analytic

### DIFF
--- a/account_analytic_tag/models/account_move_line.py
+++ b/account_analytic_tag/models/account_move_line.py
@@ -1,4 +1,6 @@
-from odoo import fields, models
+# Copyright 2024 Tecnativa - Pedro M. Baeza
+from odoo import api, fields, models
+from odoo.tools import frozendict
 
 
 class AccountMoveLine(models.Model):
@@ -8,6 +10,29 @@ class AccountMoveLine(models.Model):
         comodel_name="account.analytic.tag",
         string="Analytic Tags",
     )
+
+    @api.depends("analytic_tag_ids")
+    def _compute_all_tax(self):
+        # Include the analytic tags in the tax move line when applicable
+        res = None
+        for line in self:
+            res = super(AccountMoveLine, line)._compute_all_tax()
+            new_compute_all_tax = {}
+            for tax_key, tax_vals in line.compute_all_tax.items():
+                tax = (
+                    self.env["account.tax.repartition.line"]
+                    .browse(tax_key.get("tax_repartition_line_id", False))
+                    .tax_id
+                )
+                if tax.analytic:
+                    new_key = tax_key.copy()
+                    new_key["analytic_tag_ids"] = [
+                        (6, 0, [x.id for x in line.analytic_tag_ids])
+                    ]
+                    tax_key = frozendict(new_key)
+                new_compute_all_tax[tax_key] = tax_vals
+            line.compute_all_tax = new_compute_all_tax
+        return res
 
     def _prepare_analytic_lines(self):
         """Set tags to the records that have the same or no analytical account."""

--- a/account_analytic_tag/tests/test_account_analytic_tag.py
+++ b/account_analytic_tag/tests/test_account_analytic_tag.py
@@ -106,3 +106,17 @@ class TestAccountAnalyticTag(TestAccountAnalyticTagBase):
         self.assertNotIn(
             self.account_analytic_tag_b, self.line_a.analytic_line_ids.tag_ids
         )
+
+    def test_analytic_tags_in_tax(self):
+        tax = self.env["account.tax"].create(
+            {
+                "name": "account_analytic_tag tax example",
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "amount": 10,
+                "analytic": True,
+            }
+        )
+        self.line_a.tax_ids = [(4, tax.id)]
+        tax_line = self.invoice.line_ids.filtered(lambda x, t=tax: x.tax_line_id == t)
+        self.assertEqual(self.account_analytic_tag_a, tax_line.analytic_tag_ids)


### PR DESCRIPTION
Forward-port of #722 

If you mark explicitly a tax with analytic, or have repartition lines without account, then the analytic tags should be propagated to these lines.

@Tecnativa TT52120