### PR TITLE
[18.0][FIX] account_analytic_tag: Add analytic tags to taxes with analytic

### DIFF
--- a/account_analytic_tag/models/__init__.py
+++ b/account_analytic_tag/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_analytic_tag
 from . import account_analytic_line
 from . import account_move_line
+from . import account_tax
 from . import res_config_settings

--- a/account_analytic_tag/models/account_tax.py
+++ b/account_analytic_tag/models/account_tax.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Tecnativa - Eduardo Ezerouali
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import Command, api, models
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    @api.model
+    def _prepare_base_line_tax_repartition_grouping_key(
+        self, base_line, base_line_grouping_key, tax_data, tax_rep_data
+    ):
+        # Include the analytic tags of the base line in the tax line, following the
+        # same criteria as the analytic distribution: when the tax is flagged to be
+        # included in the analytic cost, or the repartition line has no account.
+        grouping_key = super()._prepare_base_line_tax_repartition_grouping_key(
+            base_line, base_line_grouping_key, tax_data, tax_rep_data
+        )
+        tags = self.env["account.analytic.tag"]
+        tax = tax_data["tax"]
+        tax_rep = tax_rep_data["tax_rep"]
+        if tax.analytic or not tax_rep.use_in_tax_closing:
+            tags = getattr(base_line["record"], "analytic_tag_ids", tags)
+        grouping_key["analytic_tag_ids"] = [Command.set(tags.ids)]
+        return grouping_key
+
+    @api.model
+    def _prepare_tax_line_repartition_grouping_key(self, tax_line):
+        # Keep the same key on existing tax lines so they are updated, not recreated.
+        grouping_key = super()._prepare_tax_line_repartition_grouping_key(tax_line)
+        tags = getattr(
+            tax_line["record"], "analytic_tag_ids", self.env["account.analytic.tag"]
+        )
+        grouping_key["analytic_tag_ids"] = [Command.set(tags.ids)]
+        return grouping_key

--- a/account_analytic_tag/tests/test_account_analytic_tag.py
+++ b/account_analytic_tag/tests/test_account_analytic_tag.py
@@ -106,3 +106,17 @@ class TestAccountAnalyticTag(TestAccountAnalyticTagBase):
         self.assertNotIn(
             self.account_analytic_tag_b, self.line_a.analytic_line_ids.tag_ids
         )
+
+    def test_analytic_tags_in_tax(self):
+        tax = self.env["account.tax"].create(
+            {
+                "name": "account_analytic_tag tax example",
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "amount": 10,
+                "analytic": True,
+            }
+        )
+        self.line_a.tax_ids = [(4, tax.id)]
+        tax_line = self.invoice.line_ids.filtered(lambda x, t=tax: x.tax_line_id == t)
+        self.assertEqual(self.account_analytic_tag_a, tax_line.analytic_tag_ids)


### PR DESCRIPTION
Forward-port of #722 and #723

If you mark explicitly a tax with analytic, or have repartition lines without account, then the analytic tags should be propagated to these lines.

@Tecnativa TT52120