### PR TITLE
[16.0][FIX] pos_analytic_by_config: Avoid prefixing

### DIFF
--- a/pos_analytic_by_config/migrations/16.0.1.0.0/post-migration.py
+++ b/pos_analytic_by_config/migrations/16.0.1.0.0/post-migration.py
@@ -26,18 +26,6 @@ def migrate(env, version):
     pos_configs = env["pos.config"].browse([pc.id for pc in pos_configs_dict.keys()])
     for company in pos_configs.company_id:
         company_configs = pos_configs.filtered(lambda x: x.company_id == company)
-        default_account_revenue = env["account.account"].search(
-            [
-                ("company_id", "=", company.id),
-                ("account_type", "=", "income"),
-                (
-                    "id",
-                    "!=",
-                    company.account_journal_early_pay_discount_gain_account_id.id,
-                ),
-            ],
-            limit=1,
-        )
         analytic_plan = env["account.analytic.plan"].create(
             {
                 "name": "Stores",
@@ -57,7 +45,7 @@ def migrate(env, version):
             analytic_account.plan_id = analytic_plan.id
             env["account.analytic.distribution.model"].create(
                 {
-                    "account_prefix": default_account_revenue.code[:3],
+                    "account_prefix": "",
                     "pos_config_id": config.id,
                     "analytic_distribution": {analytic_account.id: 100},
                     "company_id": company.id,

--- a/pos_analytic_by_config/tests/test_pos_analytic_by_config.py
+++ b/pos_analytic_by_config/tests/test_pos_analytic_by_config.py
@@ -28,7 +28,7 @@ class TestPosAnalyticConfig(TestPointOfSaleCommon, TestPoSCommon):
         )
         cls.env["account.analytic.distribution.model"].create(
             {
-                "account_prefix": cls.sales_account.code,
+                "account_prefix": "",
                 "pos_config_id": cls.basic_config.id,
                 "analytic_distribution": {cls.analytic_account.id: 100},
             }


### PR DESCRIPTION
Prefixing the distribution shouldn't be necessary. We can hook into the sales move lines prepare method to add or session info that later can be used to figure out the proper distribution.

cc @Tecnativa TT52559

please review @pedrobaeza @victoralmau 


Some doubts that come to my mind:

- The new technique is a little bit hackish...
- With the former approach, we could match any account from the closing session using the prefixes. Would it make any sense anyway?