### PR TITLE
[16.0][FIX] account_analytic_tag*: Post-install test + fallback to load CoA

### DIFF
--- a/account_analytic_tag/tests/common.py
+++ b/account_analytic_tag/tests/common.py
@@ -1,9 +1,8 @@
 # Copyright 2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
-from odoo.tests import common, new_test_user, tagged
+from odoo.tests import common, new_test_user
 
 
-@tagged("post_install", "-at_install")
 class TestAccountAnalyticTagBase(common.TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/account_analytic_tag/tests/test_account_analytic_tag.py
+++ b/account_analytic_tag/tests/test_account_analytic_tag.py
@@ -11,6 +11,15 @@ class TestAccountAnalyticTag(TestAccountAnalyticTagBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         invoice_form = Form(
             cls.env["account.move"]
             .with_user(cls.user)

--- a/account_analytic_tag_distribution/tests/test_account_analytic_tag_distribution.py
+++ b/account_analytic_tag_distribution/tests/test_account_analytic_tag_distribution.py
@@ -11,6 +11,15 @@ class TestAccountAnalyticTagDistribution(TestAccountAnalyticTagBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         invoice_form = Form(
             cls.env["account.move"]
             .with_user(cls.user)


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have l10n_generic_coa installed, you can't use another CoA (like l10n_es) easily, so we put little code to select the first available CoA.

@Tecnativa