### PR TITLE
[18.0]IMP] stock_analytic: make analytic distribution consistent between move and move line

### DIFF
--- a/stock_analytic/models/stock_move.py
+++ b/stock_analytic/models/stock_move.py
@@ -70,6 +70,7 @@ class StockMove(models.Model):
 
     def _action_done(self, cancel_backorder=False):
         for move in self:
+            move.move_line_ids.analytic_distribution = move.analytic_distribution
             # Validate analytic distribution only for outgoing moves.
             if move.location_id.usage not in (
                 "internal",
@@ -100,3 +101,8 @@ class StockMoveLine(models.Model):
         if self.analytic_distribution:
             res.update({"analytic_distribution": self.analytic_distribution})
         return res
+
+    def write(self, vals):
+        if "analytic_distribution" in vals:
+            self.move_id.analytic_distribution = vals["analytic_distribution"]
+        return super().write(vals)

--- a/stock_analytic/tests/test_stock_picking.py
+++ b/stock_analytic/tests/test_stock_picking.py
@@ -159,6 +159,12 @@ class CommonStockPicking(TransactionCase):
         line_count = self.env["account.move.line"].search_count(criteria2)
         self.assertEqual(line_count, 0)
 
+    def _check_analytic_consistency(self, picking):
+        for move_line in picking.move_line_ids:
+            self.assertEqual(
+                move_line.analytic_distribution, move_line.move_id.analytic_distribution
+            )
+
 
 class TestStockPicking(CommonStockPicking):
     def test_outgoing_picking_with_analytic(self):
@@ -173,6 +179,7 @@ class TestStockPicking(CommonStockPicking):
         self._picking_done_no_error(picking)
         self._check_account_move_no_error(picking)
         self._check_analytic_account_no_error(picking)
+        self._check_analytic_consistency(picking)
 
     def test_outgoing_picking_without_analytic_optional(self):
         picking = self._create_picking(
@@ -185,6 +192,7 @@ class TestStockPicking(CommonStockPicking):
         self._picking_done_no_error(picking)
         self._check_account_move_no_error(picking)
         self._check_no_analytic_account(picking)
+        self._check_analytic_consistency(picking)
 
     def test_outgoing_picking_without_analytic_mandatory(self):
         self.analytic_applicability.write({"applicability": "mandatory"})
@@ -210,6 +218,7 @@ class TestStockPicking(CommonStockPicking):
         self._picking_done_no_error(picking)
         self._check_account_move_no_error(picking)
         self._check_analytic_account_no_error(picking)
+        self._check_analytic_consistency(picking)
 
     def test_picking_add_extra_move_line(self):
         picking = self._create_picking(


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-analytic/pull/653.

@qrtl