### PR TITLE
[15.0][FIX] account_analytic_tag_default: analytic_tag_ids is computed in standard

### DIFF
--- a/account_analytic_tag_default/README.rst
+++ b/account_analytic_tag_default/README.rst
@@ -47,6 +47,12 @@ Usage
 Go to an invoice and select a analytic account in a line, default tags for the
 account are automatically applied.
 
+Known issues / Roadmap
+======================
+
+It is recommended to deprecate this module in newer versions in favor of default
+functionally of analytic defaults, since it support now tags.
+
 Bug Tracker
 ===========
 

--- a/account_analytic_tag_default/models/account_move.py
+++ b/account_analytic_tag_default/models/account_move.py
@@ -1,28 +1,22 @@
 # Copyright 2020 ForgeFlow S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import api, models
 
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    # make standard field a stored, computed, editable field.
-    analytic_tag_ids = fields.Many2many(
-        compute="_compute_analytic_tag_ids",
-        store=True,
-        readonly=False,
-    )
-
+    # Migration to 16 note: deprecate this in favor of standard analytic defaults.
     @api.depends("analytic_account_id")
     def _compute_analytic_tag_ids(self):
+        res = super()._compute_analytic_tag_ids()
         for rec in self:
             if not rec._origin and rec.analytic_tag_ids:
                 continue
             if rec.analytic_account_id.default_analytic_tag_ids:
                 rec.analytic_tag_ids = rec.analytic_account_id.default_analytic_tag_ids
-            else:
-                rec.analytic_tag_ids = False
+        return res
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/account_analytic_tag_default/readme/ROADMAP.rst
+++ b/account_analytic_tag_default/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+It is recommended to deprecate this module in newer versions in favor of default
+functionally of analytic defaults, since it support now tags.

--- a/account_analytic_tag_default/static/description/index.html
+++ b/account_analytic_tag_default/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -377,11 +376,12 @@ other tag is specified and when changing the analytic account.</p>
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -395,8 +395,13 @@ other tag is specified and when changing the analytic account.</p>
 <p>Go to an invoice and select a analytic account in a line, default tags for the
 account are automatically applied.</p>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
+<p>It is recommended to deprecate this module in newer versions in favor of default
+functionally of analytic defaults, since it support now tags.</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-analytic/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -404,21 +409,21 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
This was overlook during migration. As the module may be already installed in some instances, we corrected at least the inheritance problem, but it is possible to face weird interaction if used in conjunction with account.analytic.defaults. It is recommended to move tag defaults defined with this module to analytic default rules (account.analytic.defaut) and uninstall.