### PR TITLE
[16.0][FIX] account_analytic_distribution_manual: fix crash in post install script

### DIFF
--- a/account_analytic_distribution_manual/hooks.py
+++ b/account_analytic_distribution_manual/hooks.py
@@ -166,6 +166,7 @@ def post_init_hook(cr, registry):
             if (
                 res_model_name in env
                 and "manual_distribution_id" in env[res_model_name]._fields
+                and all_tag_ids
             ):
                 sql = f"""
                 SELECT {column1}, {column2}


### PR DESCRIPTION
Fix to avoid the following crash:

```
2025-05-22 09:05:18,221 17775 INFO test1 odoo.addons.base.models.ir_module: module account_analytic_distribution_manual: loading translation file fr for language fr_FR-
2025-05-22 09:05:18,230 17775 ERROR test1 odoo.sql_db: bad query:-
                SELECT account_analytic_tag_id, account_reconcile_model_line_id
                FROM account_reconcile_model_analytic_tag_rel
                WHERE account_analytic_tag_id IN ()
----------------
ERROR: syntax error at or near ")"
LINE 4:                 WHERE account_analytic_tag_id IN ()
                                                          ^
-
2025-05-22 09:05:18,234 17775 WARNING test1 odoo.modules.loading: Transient module states were reset-
2025-05-22 09:05:18,235 17775 ERROR test1 odoo.modules.registry: Failed to load registry-
Traceback (most recent call last):
  File "/home/alexis/new_boite/dev/16/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/alexis/new_boite/dev/16/odoo/odoo/modules/loading.py", line 489, in load_modules
    processed_modules += load_marked_modules(cr, graph,
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alexis/new_boite/dev/16/odoo/odoo/modules/loading.py", line 374, in load_marked_modules
    loaded, processed = load_module_graph(
                        ^^^^^^^^^^^^^^^^^^
  File "/home/alexis/new_boite/dev/16/odoo/odoo/modules/loading.py", line 251, in load_module_graph
    getattr(py_module, post_init)(cr, registry)
  File "/home/alexis/new_boite/dev/16/account-analytic/account_analytic_distribution_manual/hooks.py", line 175, in post_init_hook
    env.cr.execute(sql, (tuple(all_tag_ids),))
  File "/home/alexis/new_boite/dev/16/odoo/odoo/sql_db.py", line 321, in execute
    res = self._obj.execute(query, params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.SyntaxError: syntax error at or near ")"
LINE 4:                 WHERE account_analytic_tag_id IN ()
                                                          ^
```