### PR TITLE
[18.0][IMP] stock_analytic: more granularity on applicability judgment

### DIFF
--- a/stock_analytic/README.rst
+++ b/stock_analytic/README.rst
@@ -66,6 +66,20 @@ contain journal items with following rule:
    will be assigned to an analytic account according to the stock move's
    analytic account.
 
+Analytic applicability judgment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Applicability of the analytic distribution is judged based on the applicability
+settings of the analytic plan.
+
+Note that this module adds the 'Stock Move' option to the business domain, and
+'Operation Type' field.
+
+Return moves are currently outside the scope of the validation / applicability judgment
+(i.e. treated the same as optional) to allow some flexibility in the operation since
+multiple factors (e.g. applicability of the original move) may need to be considered
+to correctly judge the applicability.
+
 Bug Tracker
 ===========
 

--- a/stock_analytic/__manifest__.py
+++ b/stock_analytic/__manifest__.py
@@ -18,6 +18,7 @@
     "license": "AGPL-3",
     "depends": ["stock_account", "analytic"],
     "data": [
+        "views/account_analytic_plan_views.xml",
         "views/stock_move_views.xml",
         "views/stock_scrap_views.xml",
         "views/stock_move_line_views.xml",

--- a/stock_analytic/models/analytic_applicability.py
+++ b/stock_analytic/models/analytic_applicability.py
@@ -11,3 +11,16 @@ class AccountAnalyticApplicability(models.Model):
         selection_add=[("stock_move", "Stock Move")],
         ondelete={"stock_move": "cascade"},
     )
+    stock_picking_type_id = fields.Many2one(
+        "stock.picking.type",
+        string="Operation Type",
+    )
+
+    def _get_score(self, **kwargs):
+        score = super()._get_score(**kwargs)
+        if score >= 0 and self.stock_picking_type_id:
+            if kwargs.get("picking_type") == self.stock_picking_type_id.id:
+                score += 1
+            else:
+                return -1
+        return score

--- a/stock_analytic/models/stock_move.py
+++ b/stock_analytic/models/stock_move.py
@@ -68,18 +68,29 @@ class StockMove(models.Model):
             res.update({"analytic_distribution": self.analytic_distribution})
         return res
 
+    def _need_validate_distribution(self):
+        """Return moves are made outside the scope of the validation for now, since
+        there could be cases where the necessity cannot be judged solely by the
+        operation type.
+        """
+        self.ensure_one()
+        if self._is_in() and self._is_returned(valued_type="in"):
+            return False
+        elif self._is_out() and self._is_returned(valued_type="out"):
+            return False
+        elif self.company_id.anglo_saxon_accounting and self._is_dropshipped_returned():
+            return False
+        return True
+
     def _action_done(self, cancel_backorder=False):
         for move in self:
             move.move_line_ids.analytic_distribution = move.analytic_distribution
-            # Validate analytic distribution only for outgoing moves.
-            if move.location_id.usage not in (
-                "internal",
-                "transit",
-            ) or move.location_dest_id.usage in ("internal", "transit"):
+            if not move._need_validate_distribution():
                 continue
             move._validate_distribution(
                 **{
                     "product": move.product_id.id,
+                    "picking_type": move.picking_type_id.id,
                     "business_domain": "stock_move",
                     "company_id": move.company_id.id,
                 }

--- a/stock_analytic/readme/USAGE.rst
+++ b/stock_analytic/readme/USAGE.rst
@@ -1,0 +1,33 @@
+To Assign an Analytic Account to a Stock Move
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You need to:
+
+#. Create manually or open draft picking
+#. Add move lines and assign an **analytic account** in Analytic Distribution field
+
+Assigned Journal Items created from Stock Move with Analytic Account
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If stock move automatically create journal entry, the journal entry will
+contain journal items with following rule:
+
+#. Journal item with account equal to product's valuation account will not be
+   assigned to any analytic account.
+#. Journal item with account different to product's valuation account will be
+   assigned to an analytic account according to the stock move's analytic
+   account.
+
+Analytic applicability judgment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Applicability of the analytic distribution is judged based on the applicability
+settings of the analytic plan.
+
+Note that this module adds the 'Stock Move' option to the business domain, and
+'Operation Type' field.
+
+Return moves are currently outside the scope of the validation / applicability judgment
+(i.e. treated the same as optional) to allow some flexibility in the operation since
+multiple factors (e.g. applicability of the original move) may need to be considered
+to correctly judge the applicability.

--- a/stock_analytic/static/description/index.html
+++ b/stock_analytic/static/description/index.html
@@ -418,6 +418,17 @@ will be assigned to an analytic account according to the stock move’s
 analytic account.</li>
 </ol>
 </div>
+<div class="section" id="analytic-applicability-judgment">
+<h2><a class="toc-backref" href="#id5">Analytic applicability judgment</a></h2>
+<p>Applicability of the analytic distribution is judged based on the applicability
+settings of the analytic plan.</p>
+<p>Note that this module adds the ‘Stock Move’ option to the business domain, and
+‘Operation Type’ field.</p>
+<p>Return moves are currently outside the scope of the validation / applicability judgment
+(i.e. treated the same as optional) to allow some flexibility in the operation since
+multiple factors (e.g. applicability of the original move) may need to be considered
+to correctly judge the applicability.</p>
+</div>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-5">Bug Tracker</a></h1>

--- a/stock_analytic/tests/test_stock_picking.py
+++ b/stock_analytic/tests/test_stock_picking.py
@@ -60,14 +60,6 @@ class CommonStockPicking(TransactionCase):
         cls.analytic_distribution = dict(
             {str(cls.env.ref("analytic.analytic_agrolait").id): 100.0}
         )
-        # analytic.analytic_agrolait belongs to analytic.analytic_plan_projects
-        cls.analytic_applicability = cls.env["account.analytic.applicability"].create(
-            {
-                "business_domain": "stock_move",
-                "applicability": "optional",
-                "analytic_plan_id": cls.env.ref("analytic.analytic_plan_projects").id,
-            }
-        )
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.location = cls.warehouse.lot_stock_id
         cls.dest_location = cls.env.ref("stock.stock_location_customers")
@@ -84,6 +76,16 @@ class CommonStockPicking(TransactionCase):
             }
         )
         cls.product.update({"categ_id": cls.product_categ.id})
+
+    def _create_analytic_applicability(self):
+        # analytic.analytic_agrolait belongs to analytic.analytic_plan_projects
+        return self.env["account.analytic.applicability"].create(
+            {
+                "business_domain": "stock_move",
+                "applicability": "optional",
+                "analytic_plan_id": self.env.ref("analytic.analytic_plan_projects").id,
+            }
+        )
 
     def _create_picking(
         self,
@@ -182,6 +184,17 @@ class TestStockPicking(CommonStockPicking):
         self._check_analytic_consistency(picking)
 
     def test_outgoing_picking_without_analytic_optional(self):
+        # Create a general optional applicability for stock moves.
+        self._create_analytic_applicability()
+        # Create a another applicability which makes the analytic mandatory only for
+        # incoming stock moves. i.e. applicability should be optional for the outgoing
+        applicability_specific = self._create_analytic_applicability()
+        applicability_specific.write(
+            {
+                "stock_picking_type_id": self.incoming_picking_type.id,
+                "applicability": "mandatory",
+            }
+        )
         picking = self._create_picking(
             self.location,
             self.dest_location,
@@ -195,7 +208,15 @@ class TestStockPicking(CommonStockPicking):
         self._check_analytic_consistency(picking)
 
     def test_outgoing_picking_without_analytic_mandatory(self):
-        self.analytic_applicability.write({"applicability": "mandatory"})
+        # Create a general mandatory applicability for stock moves.
+        applicability_general = self._create_analytic_applicability()
+        applicability_general.write({"applicability": "mandatory"})
+        # Create a another applicability which makes the analytic optional only for
+        # incoming stock moves.
+        applicability_specific = self._create_analytic_applicability()
+        applicability_specific.write(
+            {"stock_picking_type_id": self.incoming_picking_type.id}
+        )
         picking = self._create_picking(
             self.location,
             self.dest_location,

--- a/stock_analytic/views/account_analytic_plan_views.xml
+++ b/stock_analytic/views/account_analytic_plan_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="account_analytic_plan_form_view" model="ir.ui.view">
+        <field name="name">account.analytic.plan.form</field>
+        <field name="model">account.analytic.plan</field>
+        <field name="inherit_id" ref="analytic.account_analytic_plan_form_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='applicability_ids']//field[@name='business_domain']"
+                position="after"
+            >
+                <field
+                    name="stock_picking_type_id"
+                    attrs="{'readonly': [('business_domain', '!=', 'stock_move')]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Forward port of #586

Before this commit, analytic distribution would be validated only for outgoing moves,
which was not ideal in view of a module such as purchase_stock_analytic.

This commit adds more flexibility to the applicability judgment by adding the stock
picking type field to the analytic applicability model, removing the assumption of
validating outgoing moves only.
