### PR TITLE
[18.0][IMP] analytic_hr_department_restriction: Convert department_id to department_ids

### DIFF
--- a/analytic_hr_department_restriction/README.rst
+++ b/analytic_hr_department_restriction/README.rst
@@ -45,8 +45,8 @@ all plans and analytical accounts without restrictions.
 Configuration
 =============
 
-- Your user must have the "Analytic Accounting" permission.
-- Create an employee linked to your user with a defined department.
+-  Your user must have the "Analytic Accounting" permission.
+-  Create an employee linked to your user with a defined department.
 
 Usage
 =====
@@ -84,10 +84,10 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Víctor Martínez
-  - Pedro M. Baeza
+   -  Víctor Martínez
+   -  Pedro M. Baeza
 
 Maintainers
 -----------

--- a/analytic_hr_department_restriction/__manifest__.py
+++ b/analytic_hr_department_restriction/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Analytic distributions restriction per HR department",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-analytic",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "depends": ["account", "hr"],
     "license": "AGPL-3",
     "category": "Account",

--- a/analytic_hr_department_restriction/migrations/18.0.1.1.0/post-migration.py
+++ b/analytic_hr_department_restriction/migrations/18.0.1.1.0/post-migration.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+from odoo.tools.sql import column_exists
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if column_exists(env.cr, "account_analytic_account", "department_id"):
+        openupgrade.m2o_to_x2m(
+            env.cr,
+            env["account.analytic.account"],
+            "account_analytic_account",
+            "department_ids",
+            "department_id",
+        )
+    if column_exists(env.cr, "account_analytic_plan", "department_id"):
+        openupgrade.m2o_to_x2m(
+            env.cr,
+            env["account.analytic.plan"],
+            "account_analytic_plan",
+            "department_ids",
+            "department_id",
+        )

--- a/analytic_hr_department_restriction/models/account_analytic_account.py
+++ b/analytic_hr_department_restriction/models/account_analytic_account.py
@@ -7,8 +7,8 @@ from odoo import fields, models
 class AccountAnalyticAccount(models.Model):
     _inherit = "account.analytic.account"
 
-    department_id = fields.Many2one(
+    department_ids = fields.Many2many(
         comodel_name="hr.department",
-        string="Department",
+        string="Departments",
         domain="['|',('company_id', '=?', company_id),('company_id', '=', False)]",
     )

--- a/analytic_hr_department_restriction/models/account_analytic_plan.py
+++ b/analytic_hr_department_restriction/models/account_analytic_plan.py
@@ -8,10 +8,9 @@ from odoo.tools import config
 class AccountAnalyticPlan(models.Model):
     _inherit = "account.analytic.plan"
 
-    department_id = fields.Many2one(
+    department_ids = fields.Many2many(
         comodel_name="hr.department",
-        string="Department",
-        company_dependent=True,
+        string="Departments",
     )
 
     def _get_all_plans(self):

--- a/analytic_hr_department_restriction/models/ir_rule.py
+++ b/analytic_hr_department_restriction/models/ir_rule.py
@@ -56,11 +56,11 @@ class IrRule(models.Model):
             user = user.with_context(allowed_company_ids=user.company_ids.ids)
             if user.has_group(group2):
                 extra_domain = [
-                    ("department_id", "child_of", user.employee_ids.department_id.ids)
+                    ("department_ids", "child_of", user.employee_ids.department_id.ids)
                 ]
                 if user.has_group(group3):
                     extra_domain = expression.OR(
-                        [extra_domain, [("department_id", "=", False)]]
+                        [extra_domain, [("department_ids", "=", False)]]
                     )
             else:
                 extra_domain = [("id", "=", 0)]

--- a/analytic_hr_department_restriction/tests/test_analytic_hr_department_restriction.py
+++ b/analytic_hr_department_restriction/tests/test_analytic_hr_department_restriction.py
@@ -76,28 +76,28 @@ class TestAnalyticHrDepartmentRestriction(BaseCommon):
         cls.plan_a = cls.env["account.analytic.plan"].create(
             {
                 "name": "Test plan A",
-                "department_id": cls.department_a.id,
+                "department_ids": [Command.set(cls.department_a.ids)],
             }
         )
         cls.account_a = cls.env["account.analytic.account"].create(
             {
                 "name": "Test account A",
                 "plan_id": cls.plan_a.id,
-                "department_id": cls.department_a.id,
+                "department_ids": [Command.set(cls.department_a.ids)],
                 "company_id": cls.env.company.id,
             }
         )
         cls.plan_b = cls.env["account.analytic.plan"].create(
             {
                 "name": "Test plan B",
-                "department_id": cls.department_b.id,
+                "department_ids": [Command.set(cls.department_b.ids)],
             }
         )
         cls.account_b = cls.env["account.analytic.account"].create(
             {
                 "name": "Test account B",
                 "plan_id": cls.plan_b.id,
-                "department_id": cls.department_b.id,
+                "department_ids": [Command.set(cls.department_b.ids)],
                 "company_id": cls.env.company.id,
             }
         )
@@ -143,12 +143,8 @@ class TestAnalyticHrDepartmentRestriction(BaseCommon):
         # the corresponding plan/analytic account even if the employee's company
         # is not selected.
         self.department_a.company_id = False
-        self.plan_a.with_company(
-            self.company_extra.id
-        ).department_id = self.department_a
-        self.plan_b.with_company(
-            self.company_extra.id
-        ).department_id = self.department_b
+        self.plan_a.department_ids = [Command.set(self.department_a.ids)]
+        self.plan_b.department_ids = [Command.set(self.department_b.ids)]
         plans = (
             self.env["account.analytic.plan"]
             .with_company(self.company_extra.id)
@@ -171,7 +167,7 @@ class TestAnalyticHrDepartmentRestriction(BaseCommon):
 
     @users("test-user")
     def test_get_relevant_plans(self):
-        self.plan_a.department_id = False
+        self.plan_a.department_ids = False
         items = self.env["account.analytic.plan"].get_relevant_plans(
             business_domain="general"
         )

--- a/analytic_hr_department_restriction/views/account_analytic_account_views.xml
+++ b/analytic_hr_department_restriction/views/account_analytic_account_views.xml
@@ -5,7 +5,11 @@
         <field name="inherit_id" ref="analytic.view_account_analytic_account_form" />
         <field name="arch" type="xml">
             <field name="plan_id" position="before">
-                <field name="department_id" groups="account.group_account_invoice" />
+                <field
+                    name="department_ids"
+                    widget="many2many_tags"
+                    groups="account.group_account_invoice"
+                />
             </field>
         </field>
     </record>
@@ -15,7 +19,8 @@
         <field name="arch" type="xml">
             <field name="plan_id" position="after">
                 <field
-                    name="department_id"
+                    name="department_ids"
+                    widget="many2many_tags"
                     groups="account.group_account_invoice"
                     optional="hide"
                 />
@@ -27,14 +32,13 @@
         <field name="inherit_id" ref="analytic.view_account_analytic_account_search" />
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
-                <field name="department_id" groups="account.group_account_invoice" />
+                <field name="department_ids" groups="account.group_account_invoice" />
             </field>
             <filter name="associatedpartner" position="after">
                 <filter
-                    string="Department"
-                    name="filter_department_id"
+                    string="Departments"
+                    name="filter_department_ids"
                     domain="[]"
-                    context="{'group_by': 'department_id'}"
                     groups="account.group_account_invoice"
                 />
             </filter>

--- a/analytic_hr_department_restriction/views/account_analytic_plan_views.xml
+++ b/analytic_hr_department_restriction/views/account_analytic_plan_views.xml
@@ -5,7 +5,11 @@
         <field name="inherit_id" ref="analytic.account_analytic_plan_form_view" />
         <field name="arch" type="xml">
             <field name="color" position="after">
-                <field name="department_id" groups="account.group_account_invoice" />
+                <field
+                    name="department_ids"
+                    widget="many2many_tags"
+                    groups="account.group_account_invoice"
+                />
             </field>
         </field>
     </record>
@@ -15,7 +19,8 @@
         <field name="arch" type="xml">
             <field name="color" position="after">
                 <field
-                    name="department_id"
+                    name="department_ids"
+                    widget="many2many_tags"
                     groups="account.group_account_invoice"
                     optional="hide"
                 />


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/account-analytic/pull/792

Convert `department_id` to `department_ids`

Ability to define multiple departments

Please @pedrobaeza and @juancarlosonate-tecnativa can you review it?

@Tecnativa TT56580