### PR TITLE
[18.0][FIX] analytic_base_department: Add missing field account_department_id

### DIFF
--- a/analytic_base_department/__manifest__.py
+++ b/analytic_base_department/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Base Analytic Department Categorization",
     "summary": "Add relationship between Analytic and Department",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "author": "Camptocamp, Daniel Reis, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Generic Modules/Projects & Services",

--- a/analytic_base_department/__manifest__.py
+++ b/analytic_base_department/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "category": "Generic Modules/Projects & Services",
     "website": "https://github.com/OCA/account-analytic",
-    "depends": ["account", "hr"],
+    "depends": ["account", "hr_timesheet"],
     "data": ["views/analytic.xml", "views/hr_department_views.xml"],
     "installable": True,
 }

--- a/analytic_base_department/models/__init__.py
+++ b/analytic_base_department/models/__init__.py
@@ -1,2 +1,3 @@
 from . import analytic
 from . import hr_department
+from . import timesheets_analysis_report

--- a/analytic_base_department/models/timesheets_analysis_report.py
+++ b/analytic_base_department/models/timesheets_analysis_report.py
@@ -1,4 +1,3 @@
-
 from odoo import fields, models
 
 

--- a/analytic_base_department/models/timesheets_analysis_report.py
+++ b/analytic_base_department/models/timesheets_analysis_report.py
@@ -1,0 +1,15 @@
+
+from odoo import fields, models
+
+
+class TimesheetsAnalysisReport(models.Model):
+    _inherit = "timesheets.analysis.report"
+
+    account_department_id = fields.Many2one(
+        comodel_name="hr.department",
+        related="department_id",
+        string="Account Department",
+        store=True,
+        readonly=True,
+        help="Account's related department",
+    )


### PR DESCRIPTION
**Issue**
When enabling **Task Logs** in *Settings → Project → Time Management*, Odoo raises an error and the feature cannot be activated.

## Steps to Reproduce
1. Go to **Settings**.
2. Open the **Project** tab.
3. Under **Time Management**, enable **Task Logs (Track time spent on projects and tasks)**.

## Support info
- Odoo version: 18.0  
- Modules: `project`, `timesheet`, `project_timesheet_holidays` (if installed)  
- User access: **Settings → Project → Time Management** 