### PR TITLE
[18.0][FIX] Skip warning when res_partner_many2one does not exist.

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,4 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING.* Missing widget: res_partner_many2one for field of type many2one.*


### PR DESCRIPTION
In the form view, the `account` module added the widget `res_partner_many2one`: https://github.com/odoo/odoo/blob/c0a7b51c9e14d29cefa96c29dd716b7aec698818/addons/account/views/account_move_views.xml#L976

In Odoo, the `partner_autocomplete` module is set to `auto_install`, but in OCB this module is not auto-installed (disabled in https://github.com/OCA/OCB/pull/1310 ).

Therefore, when any test generates a form view of `account.move`, a warning is displayed in the log, causing the test to fail.

@Tecnativa @pedrobaeza @victoralmau could you please review this?

