### PR TITLE
[15.0][FIX] purchase_analytic: add check_company to project_id field

### DIFF
--- a/purchase_analytic/models/purchase.py
+++ b/purchase_analytic/models/purchase.py
@@ -17,6 +17,7 @@ class PurchaseOrder(models.Model):
         states={"draft": [("readonly", False)]},
         store=True,
         help="The analytic account related to a purchase order.",
+        check_company=True,
     )
 
     @api.depends("order_line.account_analytic_id")


### PR DESCRIPTION
Add the check_company attribute to the analytic field to ensure consistency between companies. 