### PR TITLE
[16.0][IMP]analytic_mixin_analytic_account and stock_analytic

### DIFF
--- a/analytic_mixin_analytic_account/models/analytic_mixin.py
+++ b/analytic_mixin_analytic_account/models/analytic_mixin.py
@@ -10,12 +10,14 @@ class AnalyticMixin(models.AbstractModel):
     analytic_account_ids = fields.Many2many(
         "account.analytic.account",
         compute="_compute_analytic_account_ids",
+        compute_sudo=True,
         context={"active_test": False},
         string="Analytic Accounts",
         help="Analytic accounts computed from analytic distribution.",
     )
     analytic_account_names = fields.Char(
         compute="_compute_analytic_account_ids",
+        compute_sudo=True,
         help="Comma-separated analytic account names, in case it is useful to be "
         "included in the exported data.",
     )

--- a/stock_analytic/models/stock_move.py
+++ b/stock_analytic/models/stock_move.py
@@ -17,6 +17,19 @@ class StockMove(models.Model):
         inverse="_inverse_analytic_distribution",
     )
 
+    @api.depends('product_id', 'partner_id', 'company_id')
+    def _compute_analytic_distribution(self):
+        """ Apply analytic distribution model """
+        for move in self:
+            distribution = self.env['account.analytic.distribution.model']._get_distribution({
+                "product_id": move.product_id.id,
+                "product_categ_id": move.product_id.categ_id.id,
+                "partner_id": move.partner_id.id,
+                "partner_category_id": move.partner_id.category_id.ids,
+                "company_id": move.company_id.id,
+            })
+            move.analytic_distribution = distribution or move.analytic_distribution
+
     def _inverse_analytic_distribution(self):
         """If analytic distribution is set on move, write it on all move lines"""
         for move in self:


### PR DESCRIPTION
### analytic_mixin_analytic_account
Make it compatible with other module **account_financial_report** of **OCA/account-financial-reporting**
Just add `compute_sudo=True` to both fields `analytic_account_ids` and `analytic_account_names`, so that the console does not throw the error `account.move.line: inconsistent 'compute_sudo' for computed fields: analytic_account_ids, analytic_account_names`
Indeed this last module also computes a field `analytic_account_ids` with `store=True

### stock_analytic
Add a `_compute_analytic_distribution` method, quite generic, to apply by default the analytic distribution model at `stock.move` creation, like on any other object using analytic (purchase order, invoice, ...).