### PR TITLE
[18.0][FIX] pos_analytic_by_config

### DIFF
--- a/pos_analytic_by_config/models/analytic_distribution_model.py
+++ b/pos_analytic_by_config/models/analytic_distribution_model.py
@@ -12,8 +12,15 @@ class AccountAnalyticDistributionModel(models.Model):
         help="Select a Point of Sale for which the analytic distribution will be used",
     )
 
-    def _get_applicable_models(self, vals):
-        vals = dict(vals or {})
-        pos_config_id = self.env.context.get("pos_config_id", False)
-        vals["pos_config_id"] = pos_config_id
-        return super()._get_applicable_models(vals)
+    def _get_distribution(self, vals):
+        vals = vals.copy()
+        pos_config_id = self.env.context.get("pos_config_id")
+        if pos_config_id:
+            vals["pos_config_id"] = pos_config_id
+        res = super()._get_distribution(vals)
+        return res
+
+    def _get_default_search_domain_vals(self):
+        return super()._get_default_search_domain_vals() | {
+            "pos_config_id": False,
+        }


### PR DESCRIPTION
My first PR #831 fixed the issue where analytic distributions intended only for POS were also being applied in the backend.
However, it introduced a side effect: analytic lines started being created in flows where they shouldn’t (e.g. POS payments and session closing).

The root cause was that the _get_default_search_domain_vals method was missing. Without it, the POS-scoped models were still being matched globally in Odoo 18, since the analytic engine only filters on keys present in vals.

This new PR restores the original logic but also defines _get_default_search_domain_vals with `{"pos_config_id": False}`.