### PR TITLE
[16.0][FIX] account_analytic_distribution_manual: partial fix for bug #844

### DIFF
--- a/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.esm.js
+++ b/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.esm.js
@@ -43,12 +43,14 @@ patch(AnalyticDistribution.prototype, "account_analytic_distribution_manual", {
     },
     async save() {
         await this._super();
-        await this.props.record.update({
-            manual_distribution_id: [
-                this.state_manual_distribution.id,
-                this.state_manual_distribution.label,
-            ],
-        });
+        if (this.state_manual_distribution.id) {
+            await this.props.record.update({
+                manual_distribution_id: [
+                    this.state_manual_distribution.id,
+                    this.state_manual_distribution.label,
+                ],
+            });
+        }
     },
     async refreshManualDistribution(manual_distribution_id) {
         if (manual_distribution_id === 0) {


### PR DESCRIPTION
This is a partial fix for bug #844
Backport of the save() method from 17.0 to 16.0.
It solves the JS crash when manually configuring an analytic distribution inside the "manual operation" tab of the OCA bank reconciliation interface (module account_reconcile_oca)
It still crashes when loading a pre-configured manual analytic distribution inside the "manual operation" tab of the OCA bank reconciliation interface (but this second problem is also present in 17.0 and 18.0).