### PR TITLE
[18.0][FIX]stock_landed_costs_analytic

### DIFF
--- a/stock_landed_costs_analytic/models/stock_landed_cost_lines.py
+++ b/stock_landed_costs_analytic/models/stock_landed_cost_lines.py
@@ -1,9 +1,15 @@
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import fields, models
 
 
 class StockLandedCostLines(models.Model):
     _name = "stock.landed.cost.lines"
     _inherit = ["stock.landed.cost.lines", "analytic.mixin"]
+
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        related="cost_id.company_id",
+    )


### PR DESCRIPTION
Module error for not having company_id in stock_landed_cost_line:
  File "/home/odoo/src/odoo/odoo/models.py", line 3857, in read
    self._origin.fetch(fields)
  File "/home/odoo/src/odoo/odoo/models.py", line 4133, in fetch
    fields_to_fetch = self._determine_fields_to_fetch(field_names, ignore_when_in_cache=True)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/models.py", line 4187, in _determine_fields_to_fetch
    raise ValueError(f"Invalid field {field_name!r} on model {self._name!r}")
ValueError: Invalid field 'company_id' on model 'stock.landed.cost.lines'