### PR TITLE
[18.0][PERF] account_analytic_distribution_manual: Retrieve the analytic account information in batch

### DIFF
--- a/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.esm.js
+++ b/account_analytic_distribution_manual/static/src/components/analytic_distribution/analytic_distribution.esm.js
@@ -165,14 +165,18 @@ patch(AnalyticDistribution.prototype, {
         }
     },
     async processSelectedOption(selected_option) {
+        const analyticAccountIds = Object.keys(selected_option.analytic_distribution)
+            .map((key) => key.split(","))
+            .flat()
+            .map((id) => parseInt(id));
+        const analyticAccountDict = analyticAccountIds.length
+            ? await this.fetchAnalyticAccounts([["id", "in", analyticAccountIds]])
+            : [];
         const formattedLines = [];
         for (const [accountIds, percentage] of Object.entries(
             selected_option.analytic_distribution
         )) {
             const ids = accountIds.split(",").map((id) => parseInt(id, 10));
-            const analyticAccountDict = ids.length
-                ? await this.fetchAnalyticAccounts([["id", "in", ids]])
-                : [];
             const lineToAdd = {
                 id: this.nextId++,
                 analyticAccounts: this.plansToArray(),


### PR DESCRIPTION
Before this commit, a request was sent to the server for each analytic account. When the distribution had many accounts, this process was slow. Now, we retrieve the information for all accounts instead of one by one.

Complementary to https://github.com/OCA/account-analytic/pull/755

Before 
<img width="1532" height="867" alt="image" src="https://github.com/user-attachments/assets/66719d31-7ae7-4bfa-a605-9f0d45c8fba3" />

After
<img width="1532" height="867" alt="image" src="https://github.com/user-attachments/assets/06a6916a-52dd-4e02-b861-1b10f6d42ee4" />


TT60988
@Tecnativa @pedrobaeza @BernatObrador @peluko00  could you please review this?