### PR TITLE
[17][IMP] stock_analytic_rule: Some improvements

### DIFF
--- a/stock_analytic_rule/README.rst
+++ b/stock_analytic_rule/README.rst
@@ -1,7 +1,3 @@
-.. image:: https://odoo-community.org/readme-banner-image
-   :target: https://odoo-community.org/get-involved?utm_source=readme
-   :alt: Odoo Community Association
-
 ===================
 Stock Analytic Rule
 ===================
@@ -17,7 +13,7 @@ Stock Analytic Rule
 .. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
     :alt: Beta
-.. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-OCA%2Faccount--analytic-lightgray.png?logo=github
@@ -38,18 +34,18 @@ rules.
 
 Key features:
 
-- Define stock movement rules by source and destination locations.
-- Compute analytic line amounts using either:
+-  Define stock movement rules by source and destination locations.
+-  Compute analytic line amounts using either:
 
-  - Product list price.
-  - Category-based formula:
-    ``(avg_price * (avg_weight * qty)) + ((avg_weight * qty) * supplement)``
+   -  Product list price.
+   -  Category-based formula:
+      ``(avg_price * (avg_weight * qty)) + ((avg_weight * qty) * supplement)``
 
-- Support for positive and negative analytic distributions.
-- Handles partial distributions and multi-account combinations.
-- Supports return pickings and reversal analytic lines.
-- Fully compatible with analytic plans and multidimensional analytic
-  accounting.
+-  Support for positive and negative analytic distributions.
+-  Handles partial distributions and multi-account combinations.
+-  Supports return pickings and reversal analytic lines.
+-  Fully compatible with analytic plans and multidimensional analytic
+   accounting.
 
 The module is useful for organizations needing precise analytic
 accounting for inventory movements, such as manufacturing, logistics, or
@@ -69,9 +65,23 @@ Navigate to **Inventory > Configuration > Product Categories**.
 
 For each relevant product category, configure the following fields:
 
-- ``Average Price``: Base cost per unit.
-- ``Average Weight``: Used to scale the cost relative to quantity.
-- ``Supplement``: Additional surcharge applied on top of base cost.
+-  ``Average Price``: Base cost per unit.
+-  ``Average Weight``: Used to scale the cost relative to quantity.
+-  ``Supplement``: Additional surcharge applied on top of base cost.
+
+Custom Computation for Internal Moves
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If **Custom Computation for Internal Moves** is enabled, specific values
+can be defined for internal transfers.
+
+When this option is checked, the following fields appear:
+
+-  **Average Price for Internal Moves**
+-  **Average Weight for Internal Moves**
+
+These values will be used **instead of** **Average Price** and **Average
+Weight** when calculating the total amount for internal stock moves.
 
 These values are used when the compute type is set to **Category**.
 
@@ -81,8 +91,8 @@ These values are used when the compute type is set to **Category**.
 
 Navigate to **Accounting > Configuration > Analytic Accounting**.
 
-- Create one or more **Analytic Plans**.
-- Create **Analytic Accounts** linked to these plans.
+-  Create one or more **Analytic Plans**.
+-  Create **Analytic Accounts** linked to these plans.
 
 These accounts will be referenced in the analytic distribution logic of
 each model.
@@ -95,18 +105,18 @@ Navigate to **Accounting > Configuration > Stock Analytic Rules**.
 
 Configure each rule with:
 
-- ``Name``: Used as the label for the generated analytic lines.
-- ``Source Locations`` and ``Destination Locations``: Determines when
-  the model applies.
-- ``Amount Compute Type``: Choose between:
+-  ``Name``: Used as the label for the generated analytic lines.
+-  ``Source Locations`` and ``Destination Locations``: Determines when
+   the model applies.
+-  ``Amount Compute Type``: Choose between:
 
-  - **Product** – uses the product's list price.
-  - **Category** – uses the category's formula
-    ``(avg_price × weight × qty) + (weight × qty × supplement)``.
+   -  **Product** – uses the product's list price.
+   -  **Category** – uses the category's formula
+      ``(avg_price × weight × qty) + (weight × qty × supplement)``.
 
-- ``Analytic Distribution`` (for positive lines)
-- ``Negative Analytic Distribution`` (for negative lines)
-- ``Financial Account``: Used in the generated analytic line.
+-  ``Analytic Distribution`` (for positive lines)
+-  ``Negative Analytic Distribution`` (for negative lines)
+-  ``Financial Account``: Used in the generated analytic line.
 
 📌 **Note**: The distribution for reversed moves (e.g. returns) is
 automatically computed by inverting the accounts — no need to define a
@@ -116,9 +126,9 @@ separate rule.
 
 Create a Transfer that matches the configured rule:
 
-- It can be internal, delivery, or receipt.
+-  It can be internal, delivery, or receipt.
 
-- Ensure the source and destination locations match the analytic rule.
+-  Ensure the source and destination locations match the analytic rule.
 
 5. Review Analytic Lines
 
@@ -149,9 +159,9 @@ Authors
 Contributors
 ------------
 
-- APSL - Nagarro <https://apsl.tech>
+-  APSL - Nagarro <https://apsl.tech>
 
-  - Bernat Obrador
+   -  Bernat Obrador
 
 Maintainers
 -----------

--- a/stock_analytic_rule/models/product_category.py
+++ b/stock_analytic_rule/models/product_category.py
@@ -16,6 +16,26 @@ class ProductCategory(models.Model):
         digits=(16, 2),
         help="""This field is used to store the average weight of the products""",
     )
+
+    custom_computation_for_internal_moves = fields.Boolean(
+        string="Custom Computation for Internal Moves",
+        help="""If checked, the average price and weight for
+        internal moves will be used instead of the standard ones""",
+    )
+
+    avg_price_for_internal_moves = fields.Float(
+        string="Average Price for Internal Moves",
+        digits=(16, 2),
+        help="""This field is used to store the average price of
+        the products for internal moves""",
+    )
+    avg_weight_for_internal_moves = fields.Float(
+        string="Average Weight for Internal Moves",
+        digits=(16, 2),
+        help="""This field is used to store the average weight of
+        the products for internal moves""",
+    )
+
     supplement = fields.Float(
         digits=(16, 2),
         help="""This field is used to supplement the cost of the product""",

--- a/stock_analytic_rule/models/stock_analytic_rule.py
+++ b/stock_analytic_rule/models/stock_analytic_rule.py
@@ -73,6 +73,14 @@ class StockAnalyticRule(models.Model):
         help="If checked, couldn't validate a stock move"
         " if it doesn't generate analytic lines.",
     )
+    applicable_category_ids = fields.Many2many(
+        "product.category",
+        "stock_analytic_rule_category_rel",
+        "rule_id",
+        "category_id",
+        string="Applicable Categories",
+        help="If set, the rule will only be applied to products of these categories.",
+    )
 
     def copy(self, default=None):
         default = dict(default or {})
@@ -266,6 +274,15 @@ class StockAnalyticRule(models.Model):
                     % category.name
                 )
 
+    def _is_applicable_to_category(self, product):
+        """Return True if the rule applies to the product category."""
+        self.ensure_one()
+
+        if not self.applicable_category_ids:
+            return True
+
+        return product.categ_id in self.applicable_category_ids
+
     @api.model
     def generate_analytic_lines(self, stock_move):
         """Generates analytic lines based on matching stock analytic rules."""
@@ -290,7 +307,7 @@ class StockAnalyticRule(models.Model):
             limit=1,
         )
 
-        if record:
+        if record and record._is_applicable_to_category(product):
             # If the stock moves matches with the rule criteria,
             # then generate the analytic lines.
             amount = record._compute_amount(
@@ -298,22 +315,21 @@ class StockAnalyticRule(models.Model):
             )
             record._create_analytic_lines(amount, product, stock_move.id, company_id)
             return
-        else:
-            # Look for the reversal rule, if it exists.
-            reversal = self.search(
-                [
-                    ("location_from_ids", "in", [location_dest_id]),
-                    ("location_dest_ids", "in", [location_from_id]),
-                    ("active", "=", True),
-                    ("company_id", "=", company_id),
-                ],
-                limit=1,
-            )
+        # Look for the reversal rule, if it exists.
+        reversal = self.search(
+            [
+                ("location_from_ids", "in", [location_dest_id]),
+                ("location_dest_ids", "in", [location_from_id]),
+                ("active", "=", True),
+                ("company_id", "=", company_id),
+            ],
+            limit=1,
+        )
 
-            if reversal:
-                amount = reversal._compute_amount(
-                    product, quantity, is_internal_move, partner=partner
-                )
-                reversal._create_analytic_lines(
-                    amount, product, stock_move.id, company_id, is_reversal=True
-                )
+        if reversal and reversal._is_applicable_to_category(product):
+            amount = reversal._compute_amount(
+                product, quantity, is_internal_move, partner=partner
+            )
+            reversal._create_analytic_lines(
+                amount, product, stock_move.id, company_id, is_reversal=True
+            )

--- a/stock_analytic_rule/models/stock_analytic_rule.py
+++ b/stock_analytic_rule/models/stock_analytic_rule.py
@@ -68,6 +68,11 @@ class StockAnalyticRule(models.Model):
         default=lambda self: self.env.company,
         required=True,
     )
+    mandatory = fields.Boolean(
+        default=False,
+        help="If checked, couldn't validate a stock move"
+        " if it doesn't generate analytic lines.",
+    )
 
     def copy(self, default=None):
         default = dict(default or {})
@@ -225,25 +230,26 @@ class StockAnalyticRule(models.Model):
         return analytic_lines
 
     def _validation_checks(self, category):
-        if not category.avg_weight > 0:
-            raise ValidationError(
-                _(
-                    """This move has to generate analytic
-                    lines so the category must have a weight greater than 0.\n
-                    Please, check the category %s weight."""
+        if self.mandatory:
+            if not category.avg_weight > 0:
+                raise ValidationError(
+                    _(
+                        """This move has to generate analytic
+                        lines so the category must have a weight greater than 0.\n
+                        Please, check the category %s weight."""
+                    )
+                    % category.name
                 )
-                % category.name
-            )
 
-        if not category.avg_price > 0:
-            raise ValidationError(
-                _(
-                    """This move has to generate analytic lines
-                    so the category must have a price greater than 0.\n
-                    Please, check the category %s price."""
+            if not category.avg_price > 0:
+                raise ValidationError(
+                    _(
+                        """This move has to generate analytic lines
+                        so the category must have a price greater than 0.\n
+                        Please, check the category %s price."""
+                    )
+                    % category.name
                 )
-                % category.name
-            )
 
     @api.model
     def generate_analytic_lines(self, stock_move):

--- a/stock_analytic_rule/models/stock_analytic_rule.py
+++ b/stock_analytic_rule/models/stock_analytic_rule.py
@@ -135,25 +135,34 @@ class StockAnalyticRule(models.Model):
         )
         return tax_result["total_included"]
 
-    def _get_amount_by_category(self, product, quantity):
+    def _get_amount_by_category(self, product, quantity, is_internal_move):
         """
         Computes the amount for the analytic line based on the product's category.
         This method is used when the amount_compute_type is set to 'category'.
         """
         category = product.categ_id
+        avg_price = category.avg_price
+        avg_weight = category.avg_weight
+
+        # Use custom computation for internal moves if the flag is set and it's
+        # an internal move
+        if is_internal_move and category.custom_computation_for_internal_moves:
+            avg_price = category.avg_price_for_internal_moves
+            avg_weight = category.avg_weight_for_internal_moves
+
         self._validation_checks(category)
-        return (category.avg_price * (category.avg_weight * quantity)) + (
-            (category.avg_weight * quantity) * category.supplement
+        return (avg_price * (avg_weight * quantity)) + (
+            (avg_weight * quantity) * category.supplement
         )
 
-    def _compute_amount(self, product, quantity, partner=None):
+    def _compute_amount(self, product, quantity, is_internal_move, partner=None):
         """
         Computes the amount for the analytic line.
         """
         if self.amount_compute_type == "product":
             return self._get_amount_by_product(product, quantity, partner)
 
-        return self._get_amount_by_category(product, quantity)
+        return self._get_amount_by_category(product, quantity, is_internal_move)
 
     def _prepare_analytic_line(
         self, amount, stock_move_id, financial_account_id, company_id
@@ -231,7 +240,13 @@ class StockAnalyticRule(models.Model):
 
     def _validation_checks(self, category):
         if self.mandatory:
-            if not category.avg_weight > 0:
+            weight_error = (
+                category.avg_weight <= 0 and category.avg_weight_for_internal_moves <= 0
+            )
+            price_error = (
+                category.avg_price <= 0 and category.avg_price_for_internal_moves <= 0
+            )
+            if weight_error:
                 raise ValidationError(
                     _(
                         """This move has to generate analytic
@@ -241,7 +256,7 @@ class StockAnalyticRule(models.Model):
                     % category.name
                 )
 
-            if not category.avg_price > 0:
+            if price_error:
                 raise ValidationError(
                     _(
                         """This move has to generate analytic lines
@@ -262,6 +277,9 @@ class StockAnalyticRule(models.Model):
         company_id = stock_move.company_id.id
         partner = stock_move.partner_id
 
+        move_type = stock_move.picking_id.picking_type_code
+        is_internal_move = move_type == "internal"
+
         record = self.search(
             [
                 ("location_from_ids", "in", [location_from_id]),
@@ -275,7 +293,9 @@ class StockAnalyticRule(models.Model):
         if record:
             # If the stock moves matches with the rule criteria,
             # then generate the analytic lines.
-            amount = record._compute_amount(product, quantity, partner=partner)
+            amount = record._compute_amount(
+                product, quantity, is_internal_move, partner=partner
+            )
             record._create_analytic_lines(amount, product, stock_move.id, company_id)
             return
         else:
@@ -291,7 +311,9 @@ class StockAnalyticRule(models.Model):
             )
 
             if reversal:
-                amount = reversal._compute_amount(product, quantity, partner=partner)
+                amount = reversal._compute_amount(
+                    product, quantity, is_internal_move, partner=partner
+                )
                 reversal._create_analytic_lines(
                     amount, product, stock_move.id, company_id, is_reversal=True
                 )

--- a/stock_analytic_rule/readme/USAGE.md
+++ b/stock_analytic_rule/readme/USAGE.md
@@ -8,6 +8,17 @@ For each relevant product category, configure the following fields:
 - `Average Weight`: Used to scale the cost relative to quantity.
 - `Supplement`: Additional surcharge applied on top of base cost.
 
+### Custom Computation for Internal Moves
+
+If **Custom Computation for Internal Moves** is enabled, specific values can be defined for internal transfers.
+
+When this option is checked, the following fields appear:
+
+- **Average Price for Internal Moves**
+- **Average Weight for Internal Moves**
+
+These values will be used **instead of** **Average Price** and **Average Weight** when calculating the total amount for internal stock moves.
+
 These values are used when the compute type is set to **Category**.
 
 ---

--- a/stock_analytic_rule/tests/test_stock_analytic_rule.py
+++ b/stock_analytic_rule/tests/test_stock_analytic_rule.py
@@ -363,6 +363,7 @@ class TestStockAnalyticModel(TransactionCase):
 
     def test_validation_checks(self):
         """Test validation checks for category weight and price"""
+        self.stock_analytic_rule.mandatory = True
 
         zero_weight_category = self.env["product.category"].create(
             {
@@ -388,7 +389,6 @@ class TestStockAnalyticModel(TransactionCase):
                 "type": "product",
             }
         )
-
         product_2 = self.env["product.product"].create(
             {
                 "name": "Zero AVG Price Product",
@@ -423,6 +423,22 @@ class TestStockAnalyticModel(TransactionCase):
                     "state": "done",
                 }
             )
+
+        self.stock_analytic_rule.mandatory = False
+        move = self.env["stock.move"].create(
+            {
+                "name": "Zero Weight Move",
+                "product_id": product_1.id,
+                "product_uom": product_1.uom_id.id,
+                "product_uom_qty": 5.0,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.stock_location_2.id,
+                "state": "done",
+            }
+        )
+        self.assertTrue(
+            move, "Move should be created even with zero weight when not mandatory"
+        )
 
     def test_partial_analytic_distribution(self):
         """Test creation of analytic lines with partial distribution"""

--- a/stock_analytic_rule/tests/test_stock_analytic_rule.py
+++ b/stock_analytic_rule/tests/test_stock_analytic_rule.py
@@ -16,6 +16,24 @@ class TestStockAnalyticModel(TransactionCase):
         cls.stock_location_2 = cls.env["stock.location"].create(
             {"name": "Test Location 2"}
         )
+
+        cls.internal_location_1 = cls.env["stock.location"].create(
+            {"name": "Internal Location 1", "usage": "internal"}
+        )
+        cls.internal_location_2 = cls.env["stock.location"].create(
+            {"name": "Internal Location 2", "usage": "internal"}
+        )
+
+        cls.internal_picking_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Internal Picking Type",
+                "code": "internal",
+                "default_location_src_id": cls.internal_location_1.id,
+                "default_location_dest_id": cls.internal_location_2.id,
+                "sequence_code": "INT",
+            }
+        )
+
         cls.product_category = cls.env["product.category"].create(
             {
                 "name": "Test Category",
@@ -91,7 +109,7 @@ class TestStockAnalyticModel(TransactionCase):
         self.stock_analytic_rule.include_taxes = True
         self.product.taxes_id = [(6, 0, [self.tax.id])]
         product = self.product
-        amount = self.stock_analytic_rule._compute_amount(product, 5.0)
+        amount = self.stock_analytic_rule._compute_amount(product, 5.0, False)
         taxes = product.taxes_id.filtered(lambda t: t.company_id == self.env.company)
         price_unit = product.lst_price
         tax_result = taxes.compute_all(price_unit, quantity=5.0, product=product)
@@ -105,7 +123,7 @@ class TestStockAnalyticModel(TransactionCase):
         self.stock_analytic_rule.amount_compute_type = "product"
         self.stock_analytic_rule.include_taxes = False
         product = self.product
-        amount = self.stock_analytic_rule._compute_amount(product, 5.0)
+        amount = self.stock_analytic_rule._compute_amount(product, 5.0, False)
         expected_amount = product.lst_price * 5.0
 
         self.assertEqual(
@@ -667,4 +685,70 @@ class TestStockAnalyticModel(TransactionCase):
             round(analytic_lines2.filtered(lambda line: line.amount > 0)[0].amount, 2),
             round(expected_amount2, 2),
             "Second move should use new rule supplement",
+        )
+
+    def test_internal_moves_with_custom_computation(self):
+        """Test that internal moves use custom computation when enabled"""
+
+        self.env["stock.analytic.rule"].create(
+            {
+                "name": "Internal Move Rule",
+                "location_from_ids": [(6, 0, [self.internal_location_1.id])],
+                "location_dest_ids": [(6, 0, [self.internal_location_2.id])],
+                "analytic_distribution": {str(self.analytic_account.id): 100},
+                "analytic_distribution_negative": {
+                    str(self.analytic_account_negative.id): 100
+                },
+            }
+        )
+
+        self.product_category.custom_computation_for_internal_moves = True
+        self.product_category.avg_price_for_internal_moves = 80.0
+        self.product_category.avg_weight_for_internal_moves = 15.0
+
+        picking = self.env["stock.picking"].create(
+            {
+                "name": "Internal Move Picking",
+                "picking_type_id": self.internal_picking_type.id,
+                "location_id": self.internal_location_1.id,
+                "location_dest_id": self.internal_location_2.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        move = self.env["stock.move"].create(
+            {
+                "name": "Internal Move",
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "product_uom_qty": 6.0,
+                "quantity": 6.0,
+                "location_id": self.internal_location_1.id,
+                "location_dest_id": self.internal_location_2.id,
+                "state": "done",
+                "company_id": self.env.company.id,
+                "picking_id": picking.id,
+            }
+        )
+        analytic_lines = self.env["account.analytic.line"].search(
+            [("stock_move_id", "=", move.id)]
+        )
+        expected_amount = (
+            self.product_category.avg_price_for_internal_moves
+            * (self.product_category.avg_weight_for_internal_moves * 6.0)
+        ) + (
+            (self.product_category.avg_weight_for_internal_moves * 6.0)
+            * self.product_category.supplement
+        )
+        positive_line = analytic_lines.filtered(lambda line: line.amount > 0)
+        self.assertEqual(
+            positive_line.amount,
+            expected_amount,
+            "Amount for internal move should use custom computation values",
+        )
+        negative_line = analytic_lines.filtered(lambda line: line.amount < 0)
+        self.assertEqual(
+            negative_line.amount,
+            -expected_amount,
+            "Negative amount for internal move should use custom computation values",
         )

--- a/stock_analytic_rule/tests/test_stock_analytic_rule.py
+++ b/stock_analytic_rule/tests/test_stock_analytic_rule.py
@@ -752,3 +752,101 @@ class TestStockAnalyticModel(TransactionCase):
             -expected_amount,
             "Negative amount for internal move should use custom computation values",
         )
+
+    def test_applicable_category_ids(self):
+        """Test that the rule is only applied to specified categories"""
+
+        category_1 = self.env["product.category"].create(
+            {"name": "Category 1", "avg_price": 100.0, "avg_weight": 20.0}
+        )
+        category_2 = self.env["product.category"].create(
+            {"name": "Category 2", "avg_price": 150.0, "avg_weight": 30.0}
+        )
+
+        product_1 = self.env["product.product"].create(
+            {
+                "name": "Product 1",
+                "categ_id": category_1.id,
+                "list_price": 100.0,
+                "type": "product",
+            }
+        )
+        product_2 = self.env["product.product"].create(
+            {
+                "name": "Product 2",
+                "categ_id": category_2.id,
+                "list_price": 150.0,
+                "type": "product",
+            }
+        )
+
+        new_location = self.env["stock.location"].create({"name": "New Location"})
+        new_location_2 = self.env["stock.location"].create({"name": "New Location 2"})
+
+        self.env["stock.analytic.rule"].create(
+            {
+                "name": "Category Specific Rule",
+                "location_from_ids": [(6, 0, [new_location.id])],
+                "location_dest_ids": [(6, 0, [new_location_2.id])],
+                "analytic_distribution": {str(self.analytic_account.id): 100},
+                "analytic_distribution_negative": {
+                    str(self.analytic_account_negative.id): 100
+                },
+                "applicable_category_ids": [(6, 0, [category_1.id])],
+            }
+        )
+
+        self.env["stock.quant"].create(
+            {
+                "product_id": product_1.id,
+                "location_id": new_location.id,
+                "quantity": 50.0,
+            }
+        )
+        self.env["stock.quant"].create(
+            {
+                "product_id": product_2.id,
+                "location_id": new_location.id,
+                "quantity": 50.0,
+            }
+        )
+
+        move1 = self.env["stock.move"].create(
+            {
+                "name": "Move Product 1",
+                "product_id": product_1.id,
+                "product_uom": product_1.uom_id.id,
+                "product_uom_qty": 5.0,
+                "quantity": 5.0,
+                "location_id": new_location.id,
+                "location_dest_id": new_location_2.id,
+                "state": "done",
+                "company_id": self.env.company.id,
+            }
+        )
+        move2 = self.env["stock.move"].create(
+            {
+                "name": "Move Product 2",
+                "product_id": product_2.id,
+                "product_uom": product_2.uom_id.id,
+                "product_uom_qty": 5.0,
+                "quantity": 5.0,
+                "location_id": new_location.id,
+                "location_dest_id": new_location_2.id,
+                "state": "done",
+                "company_id": self.env.company.id,
+            }
+        )
+        analytic_lines1 = self.env["account.analytic.line"].search(
+            [("stock_move_id", "=", move1.id)]
+        )
+        analytic_lines2 = self.env["account.analytic.line"].search(
+            [("stock_move_id", "=", move2.id)]
+        )
+        self.assertTrue(
+            analytic_lines1, "Analytic lines should be created for applicable category"
+        )
+        self.assertFalse(
+            analytic_lines2,
+            "Analytic lines should not be created for non-applicable category",
+        )

--- a/stock_analytic_rule/views/product_category_views.xml
+++ b/stock_analytic_rule/views/product_category_views.xml
@@ -7,14 +7,23 @@
         <field name="inherit_id" ref="product.product_category_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='logistics']" position="before">
-                <group name="analytic" string="Analytic">
-                    <field name="avg_price" />
-                    <field name="avg_weight" />
-                    <field
+                    <group name="analytic" string="Analytic">
+                        <field name="avg_price" />
+                        <field name="avg_weight" />
+                        <field
                         name="supplement"
                         string="Supplement for Stock Analytic Models"
                     />
-                </group>
+                        <field name="custom_computation_for_internal_moves" />
+                        <field
+                        name="avg_price_for_internal_moves"
+                        invisible="not custom_computation_for_internal_moves"
+                    />
+                        <field
+                        name="avg_weight_for_internal_moves"
+                        invisible="not custom_computation_for_internal_moves"
+                    />
+                    </group>
             </xpath>
         </field>
     </record>

--- a/stock_analytic_rule/views/stock_analytic_model.xml
+++ b/stock_analytic_rule/views/stock_analytic_model.xml
@@ -101,12 +101,20 @@
 
                         <page string="Configuration">
                             <group string="Aditional Parameters" col="2">
-                                <field name="financial_account_id" />
-                                <field
-                                    name="company_id"
-                                    groups="base.group_multi_company"
-                                />
-                                <field name="active" widget="boolean_toggle" />
+                                <group>
+                                    <field name="financial_account_id" />
+                                    <field
+                                        name="company_id"
+                                        groups="base.group_multi_company"
+                                    />
+                                    <field name="active" widget="boolean_toggle" />
+                                </group>
+                                <group>
+                                    <field
+                                        name="applicable_category_ids"
+                                        widget="many2many_tags"
+                                    />
+                                </group>
                             </group>
                         </page>
                     </notebook>

--- a/stock_analytic_rule/views/stock_analytic_model.xml
+++ b/stock_analytic_rule/views/stock_analytic_model.xml
@@ -54,12 +54,17 @@
             <form>
                 <sheet>
                     <group col="2">
-                        <field name="name" required="1" />
-                        <field name="amount_compute_type" />
-                        <field
-                            name="include_taxes"
-                            invisible="amount_compute_type != 'product'"
-                        />
+                        <group>
+                            <field name="name" required="1" />
+                            <field name="amount_compute_type" />
+                            <field
+                                name="include_taxes"
+                                invisible="amount_compute_type != 'product'"
+                            />
+                        </group>
+                        <group>
+                            <field name="mandatory" />
+                        </group>
                     </group>
 
                     <notebook>


### PR DESCRIPTION
This PR improves **Stock Analytic Rules** flexibility and usability:

- [[IMP] stock_analytic_rule: Optional mandatory on analytic creation](https://github.com/OCA/account-analytic/commit/07d5987f1224008f58bac5a9393dbd8b0009f29b) Make analytic creation optionally mandatory
- [[IMP] stock_analytic_rule: Add custom computation values for internal…](https://github.com/OCA/account-analytic/commit/3ffbf662207a16ae45ae9521488b74b699d7a28b) Support custom category values for internal moves
- [[IMP] stock_analytic_rule: add category applicability check](https://github.com/OCA/account-analytic/commit/83b7e0882c3af313ca242ab5f7b5b344a1080d0e) Allow restricting rules by product categories

cc https://github.com/APSL 31663

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review
