### PR TITLE
[16.0][FIX] account_analytic_required: Check if table exists when migrating

### DIFF
--- a/account_analytic_required/migrations/16.0.2.0.0/post-migrate.py
+++ b/account_analytic_required/migrations/16.0.2.0.0/post-migrate.py
@@ -2,8 +2,12 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
 """Convert company-dependant field to normal."""
 
+from openupgradelib import openupgrade
+
 
 def migrate(cr, version):
+    if not openupgrade.table_exists(cr, "ir_property"):
+        return
     cr.execute(
         r"""
         UPDATE account_account AS acc


### PR DESCRIPTION
Check if table exists during a migration.

Useful to Enterprise migrations. 
Harmless to OCA migrations.

MT-13062 @moduon @yajo @EmilioPascual  please review if you want 😄 