### PR TITLE
[18.0][IMP] account_move_analytic_link: adjust account move button widths

### DIFF
--- a/account_move_analytic_link/views/account_move_views.xml
+++ b/account_move_analytic_link/views/account_move_views.xml
@@ -18,6 +18,7 @@
                     invisible="not analytic_line_ids"
                     icon="fa-arrow-right"
                     title="Open analytic items"
+                    width="0.1"
                 />
             </xpath>
             <xpath
@@ -31,6 +32,7 @@
                     invisible="not analytic_line_ids"
                     icon="fa-arrow-right"
                     title="Open analytic items"
+                    width="0.1"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Adjusted the column width of the analytic link button in the list view so it no longer takes up unnecessary space. This solution is based on existing Odoo core patterns ([reference](https://github.com/odoo/odoo/blob/96de54ff83965a0e2c0ec10b8ca982483071b149/addons/mrp_subcontracting/views/stock_picking_views.xml#L20)).

Without this PR:

<img width="1279" height="728" alt="image" src="https://github.com/user-attachments/assets/2419c53b-12e1-4e87-8cfd-c80c367564b2" />

With this PR:

<img width="1320" height="751" alt="image" src="https://github.com/user-attachments/assets/c38912ae-4e98-4a5f-a72e-d501ed443e7c" />
