### PR TITLE
[16.0][FIX] analytic_hr_department_restriction: auto-populate department on analytic account create

### DIFF
--- a/analytic_hr_department_restriction/models/account_analytic_account.py
+++ b/analytic_hr_department_restriction/models/account_analytic_account.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import Command, api, fields, models
 
 
 class AccountAnalyticAccount(models.Model):
@@ -12,3 +12,16 @@ class AccountAnalyticAccount(models.Model):
         string="Departments",
         domain="['|',('company_id', '=?', company_id),('company_id', '=', False)]",
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if not self.env.su:
+            user = self.env.user
+            user.invalidate_recordset(["employee_ids"])
+            user = user.with_context(allowed_company_ids=user.company_ids.ids)
+            departments = user.employee_ids.department_id
+            if departments:
+                for vals in vals_list:
+                    if not vals.get("department_ids"):
+                        vals["department_ids"] = [Command.set(departments.ids)]
+        return super().create(vals_list)

--- a/analytic_hr_department_restriction/tests/test_analytic_hr_department_restriction.py
+++ b/analytic_hr_department_restriction/tests/test_analytic_hr_department_restriction.py
@@ -184,6 +184,33 @@ class TestAnalyticHrDepartmentRestriction(BaseCommon):
         self.assertNotIn(self.account_b, accounts)
         self.assertIn(self.account_c, accounts)
 
+    @users("test-user")
+    def test_analytic_account_create_auto_department(self):
+        """Creating an analytic account without department_ids should auto-populate
+        them from the user's employee department, so the ir.rule doesn't block it."""
+        account = self.env["account.analytic.account"].create(
+            {
+                "name": "Test account auto department",
+                "plan_id": self.plan_a.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        self.assertEqual(account.department_ids, self.department_a)
+
+    @users("test-user")
+    def test_analytic_account_create_explicit_department(self):
+        """Creating an analytic account with explicit department_ids should not
+        be overridden by the auto-population."""
+        account = self.env["account.analytic.account"].create(
+            {
+                "name": "Test account explicit department",
+                "plan_id": self.plan_a.id,
+                "department_ids": [Command.set(self.department_a.ids)],
+                "company_id": self.env.company.id,
+            }
+        )
+        self.assertEqual(account.department_ids, self.department_a)
+
     @users("test-manager")
     def test_analytic_data_manager(self):
         plans = self.env["account.analytic.plan"].search([])


### PR DESCRIPTION
When creating a new project, Odoo creates a new analytic account without department_ids. The ir.rule restriction then blocks the operation because the empty department_ids doesn't match the user's department domain.

Auto-populate department_ids from the user's employee department(s) when creating analytic accounts without explicit department_ids, so the ir.rule passes naturally without weakening the security restriction.