### PR TITLE
[FIX] account_analytic_tag: fix broken xpaths for Odoo 19 view structure

### DIFF
--- a/account_analytic_tag/views/account_move_views.xml
+++ b/account_analytic_tag/views/account_move_views.xml
@@ -5,8 +5,9 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
+            <!-- invoice_line_ids list was given name="journal_items" in Odoo 19 -->
             <xpath
-                expr="//field[@name='invoice_line_ids']/list/field[@name='analytic_distribution']"
+                expr="//field[@name='invoice_line_ids']/list[@name='journal_items']/field[@name='analytic_distribution']"
                 position="after"
             >
                 <field
@@ -17,8 +18,9 @@
                     options="{'color_field': 'color'}"
                 />
             </xpath>
+            <!-- line_ids was renamed to journal_line_ids in Odoo 19 -->
             <xpath
-                expr="//field[@name='line_ids']/list/field[@name='analytic_distribution']"
+                expr="//field[@name='journal_line_ids']/list/field[@name='analytic_distribution']"
                 position="after"
             >
                 <field


### PR DESCRIPTION
## Summary

Two breaking view structure changes in Odoo 19 prevent `account_analytic_tag` from installing:

### 1. `invoice_line_ids` list element renamed
The `<list>` inside `invoice_line_ids` was given `name="journal_items"` in Odoo 19.
The xpath must match `list[@name='journal_items']` instead of bare `list`.

### 2. `line_ids` renamed to `journal_line_ids`
The Journal Items tab field was renamed from `line_ids` to `journal_line_ids` in Odoo 19.

## Changes
- `account_analytic_tag/views/account_move_views.xml`: update two xpaths to match Odoo 19 view structure

## Test
Verified on Odoo 19.0 Community — module installs and `analytic_tag_ids` column appears correctly in both Invoice Lines and Journal Items tabs.