### PR TITLE
[17.0][FIX] account_move_update_analytic: strip unchanged integrity fields before hash check

### DIFF
--- a/account_move_update_analytic/models/__init__.py
+++ b/account_move_update_analytic/models/__init__.py
@@ -1,1 +1,2 @@
 from . import account_move
+from . import account_move_line

--- a/account_move_update_analytic/models/account_move_line.py
+++ b/account_move_update_analytic/models/account_move_line.py
@@ -1,0 +1,30 @@
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def write(self, vals):
+        if not vals:
+            return True
+        # The Odoo core hash check blocks writes where integrity fields appear in vals,
+        # even if unchanged. Updating analytic_distribution causes
+        # _sync_dynamic_line to include account_id in the tax line write,
+        # triggering a false positive. Strip unchanged integrity fields from
+        # vals so the check only fires on real modifications.
+        hashed = self.filtered(lambda line: line.move_id.inalterable_hash)
+        if self.env.context.get("update_analytic") and hashed:
+            integrity_fields = set(self._get_integrity_hash_fields()).union(
+                {"inalterable_hash", "secure_sequence_number"}
+            )
+            unchanged = {
+                fname
+                for fname in integrity_fields & set(vals)
+                if not any(
+                    self.env["account.move"]._field_will_change(line, vals, fname)
+                    for line in hashed
+                )
+            }
+            if unchanged:
+                vals = {k: v for k, v in vals.items() if k not in unchanged}
+        return super().write(vals)

--- a/account_move_update_analytic/wizards/account_move_update_analytic.py
+++ b/account_move_update_analytic/wizards/account_move_update_analytic.py
@@ -62,8 +62,12 @@ class AccountMoveUpdateAnalytic(models.TransientModel):
         self.ensure_one()
         # Validate if mandatory plans has 100%
         self.with_context(validate_analytic=True)._validate_distribution()
-        if self.line_id:
-            self.line_id.analytic_distribution = self.analytic_distribution
-        else:
-            moves = self.env["account.move"].browse(self.env.context.get("active_ids"))
-            moves.invoice_line_ids.analytic_distribution = self.analytic_distribution
+        lines = (
+            self.line_id
+            or self.env["account.move"]
+            .browse(self.env.context.get("active_ids"))
+            .invoice_line_ids
+        )
+        lines.with_context(update_analytic=True).write(
+            {"analytic_distribution": self.analytic_distribution}
+        )


### PR DESCRIPTION
When `restrict_mode_hash_table` is active, updating `analytic_distribution` on a posted invoice triggers `_sync_dynamic_line` to rewrite the tax line with its full key dict — always including `account_id` even if unchanged. The OCB hash check raises a false positive:


```
odoo.exceptions.UserError: You cannot edit the following fields: Account, Label, Partner.
The following entries are already hashed: INV/2026/XXXXX
```

This fix strips integrity-hash fields from `vals` when their value has not actually changed, so the check only fires on real modifications.

**Note**: This issue only occurs when the tax has the "Include in analytic" option enabled (`analytic` field on `account.tax`), as this makes `analytic_distribution` part of the tax key in `_compute_all_tax`, triggering the `_sync_dynamic_line` rewrite.

@Tecnativa TT61686
@christian-ramos-tecnativa @pedrobaeza 