### PR TITLE
[18.0][FIX] account_move_update_analytic: update tax lines analytic on posted moves

### DIFF
--- a/account_move_update_analytic/tests/__init__.py
+++ b/account_move_update_analytic/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_move_update_analytic

--- a/account_move_update_analytic/tests/test_account_move_update_analytic.py
+++ b/account_move_update_analytic/tests/test_account_move_update_analytic.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Tecnativa - Christian Ramos
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from odoo.fields import Command
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountAnalyticTagBase(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                mail_create_nolog=True,
+                mail_create_nosubscribe=True,
+                mail_notrack=True,
+                no_reset_password=True,
+                tracking_disable=True,
+            )
+        )
+        # ==== For Accounting ====
+        cls.default_plan = cls.env["account.analytic.plan"].create({"name": "Default"})
+        cls.analytic_account_a = cls.env["account.analytic.account"].create(
+            {
+                "name": "analytic_account_a",
+                "plan_id": cls.default_plan.id,
+            }
+        )
+        cls.analytic_account_b = cls.env["account.analytic.account"].create(
+            {
+                "name": "analytic_account_b",
+                "plan_id": cls.default_plan.id,
+            }
+        )
+        # ==== For Invoices ====
+        cls.tax_id = cls.env["account.tax"].create(
+            {
+                "name": "Tax 10%",
+                "amount_type": "percent",
+                "amount": 10.0,
+                "analytic": True,
+                "type_tax_use": "sale",
+            }
+        )
+        cls.product_a = cls.env["product.product"].create(
+            {
+                "name": "product_a",
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                "lst_price": 100.0,
+                "taxes_id": [Command.link(cls.tax_id.id)],
+            }
+        )
+        cls.product_b = cls.env["product.product"].create(
+            {
+                "name": "product_b",
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                "lst_price": 100.0,
+                "taxes_id": [Command.link(cls.tax_id.id)],
+            }
+        )
+        cls.partner_a = cls.env["res.partner"].create(
+            {"name": "partner_a", "vat": "999999999"}
+        )
+        cls.invoice = cls.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": cls.partner_a.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product_a.id,
+                            "quantity": 1.0,
+                            "price_unit": 100.0,
+                            "analytic_distribution": {cls.analytic_account_a.id: 100},
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product_b.id,
+                            "quantity": 2.0,
+                            "price_unit": 100.0,
+                            "analytic_distribution": {
+                                cls.analytic_account_a.id: 100,
+                            },
+                        },
+                    ),
+                ],
+            }
+        )
+
+    def test_update_analytic(self):
+        self.invoice.action_post()
+        self.assertEqual(
+            len(
+                self.invoice.line_ids.filtered(
+                    lambda line, self=self: line.analytic_distribution
+                    == {str(self.analytic_account_a.id): 100}
+                )
+            ),
+            3,
+        )
+        self.env["account.move.update.analytic.wizard"].create(
+            {
+                "line_id": self.invoice.invoice_line_ids[0].id,
+                "analytic_distribution": {str(self.analytic_account_b.id): 100},
+            }
+        ).update_analytic_lines()
+        # After the update, we should have 2 lines with analytic_account_b
+        # and 2 lines with analytic_account_a, because the tax 10% line gets
+        # split into two lines, one with analytic_account_a and another one
+        # with analytic_account_b
+        self.assertEqual(
+            len(
+                self.invoice.line_ids.filtered(
+                    lambda line, self=self: line.analytic_distribution
+                    == {str(self.analytic_account_b.id): 100}
+                )
+            ),
+            2,
+        )
+        self.assertEqual(
+            len(
+                self.invoice.line_ids.filtered(
+                    lambda line, self=self: line.analytic_distribution
+                    == {str(self.analytic_account_a.id): 100}
+                )
+            ),
+            2,
+        )

--- a/account_move_update_analytic/wizards/account_move_update_analytic.py
+++ b/account_move_update_analytic/wizards/account_move_update_analytic.py
@@ -109,12 +109,58 @@ class AccountMoveUpdateAnalytic(models.TransientModel):
                         # lines share both the same tax and the same analytic
                         # distribution, Odoo combines them into one tax line
                         # whose balance is the sum — amount matching fails, so
-                        # we fall back to distribution matching only.
-                        extra_lines = move.line_ids.filtered(
+                        # we check each candidate and split if needed.
+                        merged_candidates = move.line_ids.filtered(
                             lambda line: line.display_type == "tax"
                             and line.tax_line_id in analytic_taxes
                             and line.analytic_distribution == current_dist
                         )
+                        for merged_line in merged_candidates:
+                            expected_amount = expected.get(
+                                merged_line.tax_repartition_line_id.id, 0
+                            )
+                            can_split = (
+                                expected_amount
+                                and not move.currency_id.is_zero(
+                                    abs(merged_line.balance) - expected_amount
+                                )
+                                and not merged_line.move_id.inalterable_hash
+                            )
+                            if can_split:
+                                # Merged line: shrink to remaining amount,
+                                # create a new line for this product's share.
+                                sign = 1 if merged_line.balance >= 0 else -1
+                                new_balance = sign * expected_amount
+                                remaining_balance = merged_line.balance - new_balance
+                                ctx = dict(self.env.context, check_move_validity=False)
+                                merged_line.with_context(**ctx).write(
+                                    {
+                                        "debit": max(remaining_balance, 0),
+                                        "credit": max(-remaining_balance, 0),
+                                    }
+                                )
+                                self.env["account.move.line"].with_context(
+                                    **ctx
+                                ).create(
+                                    {
+                                        "move_id": move.id,
+                                        "account_id": merged_line.account_id.id,
+                                        "name": merged_line.name,
+                                        "partner_id": merged_line.partner_id.id,
+                                        "tax_line_id": merged_line.tax_line_id.id,
+                                        "tax_repartition_line_id": (
+                                            merged_line.tax_repartition_line_id.id
+                                        ),
+                                        "display_type": "tax",
+                                        "debit": max(new_balance, 0),
+                                        "credit": max(-new_balance, 0),
+                                        "analytic_distribution": (
+                                            self.analytic_distribution
+                                        ),
+                                    }
+                                )
+                            else:
+                                extra_lines |= merged_line
                 (
                     self.line_id | extra_lines
                 ).analytic_distribution = self.analytic_distribution

--- a/account_move_update_analytic/wizards/account_move_update_analytic.py
+++ b/account_move_update_analytic/wizards/account_move_update_analytic.py
@@ -63,7 +63,70 @@ class AccountMoveUpdateAnalytic(models.TransientModel):
         # Validate if mandatory plans has 100%
         self.with_context(validate_analytic=True)._validate_distribution()
         if self.line_id:
-            self.line_id.analytic_distribution = self.analytic_distribution
+            if (
+                self.line_id.display_type == "product"
+                and self.line_id.parent_state == "posted"
+            ):
+                # _sync_tax_lines skips posted moves (state != 'draft' guard in core),
+                # so tax lines with 'Include in Analytic Cost' must be updated
+                # explicitly.
+                move = self.line_id.move_id
+                analytic_taxes = self.line_id.tax_ids.filtered("analytic")
+                extra_lines = self.env["account.move.line"]
+                if analytic_taxes:
+                    # Identify this product line's tax lines by combining two
+                    # conditions: (1) the expected tax amount computed via
+                    # compute_all, and (2) the current analytic distribution.
+                    # Using both together handles same-amount/same-distribution
+                    # edge cases that neither condition solves alone.
+                    is_refund = move.move_type in ("out_refund", "in_refund")
+                    price = self.line_id.price_unit * (1 - self.line_id.discount / 100)
+                    taxes_res = analytic_taxes.compute_all(
+                        price,
+                        currency=move.currency_id,
+                        quantity=self.line_id.quantity,
+                        product=self.line_id.product_id,
+                        partner=move.partner_id,
+                        is_refund=is_refund,
+                    )
+                    expected = {
+                        t["tax_repartition_line_id"]: abs(t["amount"])
+                        for t in taxes_res["taxes"]
+                        if t.get("tax_repartition_line_id")
+                    }
+                    current_dist = self.line_id.analytic_distribution
+                    extra_lines = move.line_ids.filtered(
+                        lambda line: line.display_type == "tax"
+                        and line.tax_line_id in analytic_taxes
+                        and line.analytic_distribution == current_dist
+                        and move.currency_id.is_zero(
+                            abs(line.balance)
+                            - expected.get(line.tax_repartition_line_id.id, -1)
+                        )
+                    )
+                    if not extra_lines:
+                        # Fallback for merged tax lines: when multiple product
+                        # lines share both the same tax and the same analytic
+                        # distribution, Odoo combines them into one tax line
+                        # whose balance is the sum — amount matching fails, so
+                        # we fall back to distribution matching only.
+                        extra_lines = move.line_ids.filtered(
+                            lambda line: line.display_type == "tax"
+                            and line.tax_line_id in analytic_taxes
+                            and line.analytic_distribution == current_dist
+                        )
+                (
+                    self.line_id | extra_lines
+                ).analytic_distribution = self.analytic_distribution
+            else:
+                self.line_id.analytic_distribution = self.analytic_distribution
         else:
             moves = self.env["account.move"].browse(self.env.context.get("active_ids"))
-            moves.invoice_line_ids.analytic_distribution = self.analytic_distribution
+            # _sync_tax_lines skips posted moves, so tax and payment_term lines
+            # must be updated explicitly alongside invoice product lines.
+            extra_lines = moves.line_ids.filtered(
+                lambda line: line.display_type == "tax" and line.tax_line_id.analytic
+            )
+            (
+                moves.invoice_line_ids | extra_lines
+            ).analytic_distribution = self.analytic_distribution


### PR DESCRIPTION
When using the wizard on a posted invoice, two issues were fixed:

- **Tax lines not updated:** `_sync_tax_lines` skips posted moves, so tax lines with "Include in Analytic Cost" were never updated. The fix updates them explicitly alongside the product line.

- **Wrong tax lines updated:** when multiple products share the same analytic tax, all their tax lines were updated instead of only the edited product's. The fix uses each tax line's `analytic_distribution` to identify which product it belongs to (Odoo sets it from the product line's distribution via `_prepare_base_line_tax_repartition_grouping_key`).

FWP [#914 ](https://github.com/OCA/account-analytic/pull/914)

@Tecnativa TT61686
@pedrobaeza @christian-ramos-tecnativa 