### PR TITLE
[12.0][FIX] account_analytic_default_account: skip catch-all default when searching by account

### DIFF
--- a/account_analytic_default_account/models/account_analytic_default_account.py
+++ b/account_analytic_default_account/models/account_analytic_default_account.py
@@ -71,6 +71,12 @@ class AccountAnalyticDefaultAccount(models.Model):
             if index > best_index:
                 res = rec
                 best_index = index
+        # When searching by account_id (move line context without partner), do not
+        # return a catch-all record with no conditions set. Returning score-0 records
+        # here would cause any unconditional default to be applied to every accounting
+        # entry that lacks a specific rule, which is never the intended behaviour.
+        if account_id and best_index == 0:
+            return self.env['account.analytic.default']
         return res
 
 


### PR DESCRIPTION
When account_id is provided to account_get (move line creation context), a record with no conditions set scores 0 and wins only by default (best_index starts at -1). This causes any unconditional analytic default to be applied to every accounting entry without a specific rule, such as inventory adjustment lines. Return empty when account_id is given and the best match has no conditions set.