### PR TITLE
[18.0][FIX] analytic_base_department: delete account_department_id in view

### DIFF
--- a/analytic_base_department/views/analytic.xml
+++ b/analytic_base_department/views/analytic.xml
@@ -70,7 +70,6 @@
         <field name="arch" type="xml">
             <field name="date" position="after">
                 <field name="department_id" />
-                <field name="account_department_id" />
             </field>
             <xpath expr="//filter[@name='group_date']" position="after">
                 <filter
@@ -82,11 +81,6 @@
                     name="department"
                     string="Department"
                     context="{'group_by':'department_id'}"
-                />
-                <filter
-                    name="account_department"
-                    string="Account Department"
-                    context="{'group_by':'account_department_id'}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Can't install module `hr_timesheet` after install `analytic_base_department`

Step to reproduce:
1. Install module analytic_base_department
2. Install module hr_timesheet
3. It will error

```
odoo.tools.convert.ParseError: while parsing /opt/odoo/auto/addons/hr_timesheet/report/hr_timesheet_report_view.xml:125
Error while validating view near:

<search string="Timesheet Report" __validate__="1">
    <field name="name"/>
    <field name="date"/>
    <field name="department_id"/>
<field name="account_department_id"/>

Field "account_department_id" does not exist in model "timesheets.analysis.report"
```