### PR TITLE
[17.0][FIX] account_move_update_analytic: Add force_delete for journal items merge

### DIFF
--- a/account_move_update_analytic/wizards/account_move_update_analytic.py
+++ b/account_move_update_analytic/wizards/account_move_update_analytic.py
@@ -68,6 +68,6 @@ class AccountMoveUpdateAnalytic(models.TransientModel):
             .browse(self.env.context.get("active_ids"))
             .invoice_line_ids
         )
-        lines.with_context(update_analytic=True).write(
+        lines.with_context(update_analytic=True, force_delete=True).write(
             {"analytic_distribution": self.analytic_distribution}
         )


### PR DESCRIPTION
When performing an analytic update is posible that during the sync_lines if the analytic distribution and tax is the same it will try to merge the journal items. Raising the error:
```
Invalid Operation
You can't delete a posted journal item. Don’t play games with your accounting records; reset the journal entry to draft before deleting it.
```
This should be a safe delete, similar to how it creates new items when analytic distribution differs

@Tecnativa TT62858
@pedrobaeza 