### PR TITLE
[FIX] analytic_base_department: expose account_department_id in timesheets report

### DIFF
--- a/analytic_base_department/__manifest__.py
+++ b/analytic_base_department/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "category": "Generic Modules/Projects & Services",
     "website": "https://github.com/OCA/account-analytic",
-    "depends": ["account", "hr"],
+    "depends": ["account", "hr", "hr_timesheet"],
     "data": ["views/analytic.xml", "views/hr_department_views.xml"],
     "installable": True,
 }

--- a/analytic_base_department/models/__init__.py
+++ b/analytic_base_department/models/__init__.py
@@ -1,2 +1,3 @@
 from . import analytic
 from . import hr_department
+from . import hr_timesheet_report

--- a/analytic_base_department/models/hr_timesheet_report.py
+++ b/analytic_base_department/models/hr_timesheet_report.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models
+
+
+class TimesheetsAnalysisReport(models.Model):
+    """Expose account_department_id on the timesheets reporting SQL view.
+
+    hr_timesheet's own report search view (a "primary" view on this model)
+    inherits its arch from analytic.view_account_analytic_line_filter, the
+    same shared ancestor this module extends with account_department_id.
+    Without this field existing here too, that combination fails validating
+    as soon as both modules are installed together.
+    """
+
+    _inherit = "timesheets.analysis.report"
+
+    account_department_id = fields.Many2one(
+        comodel_name="hr.department",
+        string="Account Department",
+        readonly=True,
+    )
+
+    @api.model
+    def _select(self):
+        return super()._select() + ", A.account_department_id AS account_department_id"

--- a/analytic_base_department/tests/__init__.py
+++ b/analytic_base_department/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_line_department
+from . import test_hr_timesheet_report

--- a/analytic_base_department/tests/test_hr_timesheet_report.py
+++ b/analytic_base_department/tests/test_hr_timesheet_report.py
@@ -1,0 +1,41 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tests.common import TransactionCase
+
+
+class TimesheetsReportDepartmentCase(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.department = cls.env.ref("hr.dep_rd")
+        cls.plan = cls.env.ref("analytic.analytic_plan_projects")
+        cls.account = cls.env["account.analytic.account"].create(
+            {
+                "name": "Test analytic account",
+                "department_id": cls.department.id,
+                "plan_id": cls.plan.id,
+            }
+        )
+        cls.project = cls.env["project.project"].create(
+            {"name": "Test project", "account_id": cls.account.id}
+        )
+        cls.employee = cls.env.ref("hr.employee_admin")
+        cls.line = cls.env["account.analytic.line"].create(
+            {
+                "name": "Test timesheet line",
+                "account_id": cls.account.id,
+                "project_id": cls.project.id,
+                "employee_id": cls.employee.id,
+                "unit_amount": 1.0,
+            }
+        )
+
+    def test_account_department_id_in_report(self):
+        """account_department_id must be readable from the reporting view.
+
+        Without this fix, timesheets.analysis.report doesn't expose the
+        field at all, which breaks the shared search view arch as soon as
+        both analytic_base_department and hr_timesheet are installed
+        together.
+        """
+        report_line = self.env["timesheets.analysis.report"].browse(self.line.id)
+        self.assertEqual(report_line.account_department_id, self.department)


### PR DESCRIPTION
analytic_base_department inserts account_department_id in the shared
view analytic.view_account_analytic_line_filter. hr_timesheet has its
own report view (hr_timesheet_report_search), a "primary" view on the
SQL model timesheets.analysis.report that inherits its combined arch
from that same shared view -- but that reporting model only exposes a
subset of account.analytic.line's fields (it did not include
account_department_id), so the view fails validating as soon as both
modules are installed together (reproduced both on a clean install and
on an -u against a real, already populated database).

Fix: expose account_department_id also on timesheets.analysis.report
(models/hr_timesheet_report.py), extending _select() the same way core
hr_timesheet already does for department_id. Requires depending on
hr_timesheet explicitly -- without it, analytic_base_department could
load before hr_timesheet in the module graph, and this file's
extension would never make it in time to prevent the failure.

Adds a test that reads account_department_id back from
timesheets.analysis.report, which fails before this fix (field does
not exist on the model) and passes after.

