### PR TITLE
[18.0][IMP] hr_expense_analytic_tag: Do not allow the field to be modified if is_editable

### DIFF
--- a/hr_expense_analytic_tag/views/hr_expense_view.xml
+++ b/hr_expense_analytic_tag/views/hr_expense_view.xml
@@ -10,6 +10,7 @@
                     name="analytic_tag_ids"
                     groups="account_analytic_tag.group_analytic_tags"
                     widget="many2many_tags"
+                    readonly="not is_editable"
                 />
             </field>
         </field>


### PR DESCRIPTION
Do not allow the field to be modified if `is_editable`

The `readonly="not is_editable"` attribute is used in all fields; therefore, it must also be used in the `analytic_tag_ids` field

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa