### PR TITLE
[19.0][FIX] hr_expense_analytic_tag: Add payment_mode=company_account compatibility

### DIFF
--- a/hr_expense_analytic_tag/models/hr_expense.py
+++ b/hr_expense_analytic_tag/models/hr_expense.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Tecnativa - Víctor Martínez
+# Copyright 2023-2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import Command, fields, models
@@ -18,3 +18,13 @@ class HrExpense(models.Model):
         if self.analytic_tag_ids:
             vals.update({"analytic_tag_ids": [Command.set(self.analytic_tag_ids.ids)]})
         return vals
+
+    def _prepare_payments_vals(self):
+        move_vals, payment_vals = super()._prepare_payments_vals()
+        if self.analytic_tag_ids:
+            for _, _, line_vals in move_vals["line_ids"]:
+                if line_vals.get("expense_id") and line_vals["expense_id"] == self.id:
+                    line_vals.update(
+                        {"analytic_tag_ids": [Command.set(self.analytic_tag_ids.ids)]}
+                    )
+        return move_vals, payment_vals

--- a/hr_expense_analytic_tag/tests/test_hr_expense_analytic_tag.py
+++ b/hr_expense_analytic_tag/tests/test_hr_expense_analytic_tag.py
@@ -1,12 +1,12 @@
-# Copyright 2023-2024 Tecnativa - Víctor Martínez
+# Copyright 2023-2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo.tests import Form, tagged
+from odoo.tools import mute_logger
 
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 
 
-@tagged("-at_install", "post_install")
-class TestHrExpenseAnalyticTag(TestExpenseCommon):
+class TestHrExpenseAnalyticTagBase(TestExpenseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -25,29 +25,40 @@ class TestHrExpenseAnalyticTag(TestExpenseCommon):
         expense_form.name = "Test expense"
         return expense_form.save()
 
-    def test_hr_expense_with_tag(self):
+    def _action_post_expense(self):
+        res = self.expense.action_post()
+        if res:
+            wizard = (
+                self.env[res["res_model"]].with_context(**res["context"]).create({})
+            )
+            wizard.action_post_entry()
+
+    @mute_logger("odoo.models.unlink")
+    def _test_hr_expense_with_tag(self):
         """Tag without analytic accounts."""
         self.expense.analytic_distribution = {self.analytic_account_1.id: 100}
         self.expense.analytic_tag_ids = self.analytic_tag_1
         self.expense._do_approve(check=False)
-        self.expense._post_without_wizard()
+        self._action_post_expense()
         move = self.expense.account_move_id
         tags = move.mapped("line_ids.analytic_line_ids.tag_ids")
         self.assertIn(self.analytic_tag_1, tags)
         self.assertNotIn(self.analytic_tag_2, tags)
 
-    def test_hr_expense_with_tags_01(self):
+    @mute_logger("odoo.models.unlink")
+    def _test_hr_expense_with_tags_01(self):
         """Tags without analytic accounts."""
         self.expense.analytic_distribution = {self.analytic_account_1.id: 100}
         self.expense.analytic_tag_ids = self.analytic_tag_1 + self.analytic_tag_2
         self.expense._do_approve(check=False)
-        self.expense._post_without_wizard()
+        self._action_post_expense()
         move = self.expense.account_move_id
         tags = move.mapped("line_ids.analytic_line_ids.tag_ids")
         self.assertIn(self.analytic_tag_1, tags)
         self.assertIn(self.analytic_tag_2, tags)
 
-    def test_hr_expense_with_tags_02(self):
+    @mute_logger("odoo.models.unlink")
+    def _test_hr_expense_with_tags_02(self):
         """Tags with analytic account and expense analytic account 1 + 2."""
         self.analytic_tag_1.account_analytic_id = self.analytic_account_1
         self.analytic_tag_2.account_analytic_id = self.analytic_account_2
@@ -57,13 +68,14 @@ class TestHrExpenseAnalyticTag(TestExpenseCommon):
         }
         self.expense.analytic_tag_ids = self.analytic_tag_1 + self.analytic_tag_2
         self.expense._do_approve(check=False)
-        self.expense._post_without_wizard()
+        self._action_post_expense()
         move = self.expense.account_move_id
         tags = move.mapped("line_ids.analytic_line_ids.tag_ids")
         self.assertIn(self.analytic_tag_1, tags)
         self.assertIn(self.analytic_tag_2, tags)
 
-    def test_hr_expense_with_tags_03(self):
+    @mute_logger("odoo.models.unlink")
+    def _test_hr_expense_with_tags_03(self):
         """Tags with analytic account and expense analytic account 1."""
         self.analytic_tag_1.account_analytic_id = self.analytic_account_1
         self.analytic_tag_2.account_analytic_id = self.analytic_account_2
@@ -72,17 +84,64 @@ class TestHrExpenseAnalyticTag(TestExpenseCommon):
         }
         self.expense.analytic_tag_ids = self.analytic_tag_1 + self.analytic_tag_2
         self.expense._do_approve(check=False)
-        self.expense._post_without_wizard()
+        self._action_post_expense()
         move = self.expense.account_move_id
         tags = move.mapped("line_ids.analytic_line_ids.tag_ids")
         self.assertIn(self.analytic_tag_1, tags)
         self.assertNotIn(self.analytic_tag_2, tags)
 
-    def test_hr_expense_without_tags(self):
+    @mute_logger("odoo.models.unlink")
+    def _test_hr_expense_without_tags(self):
         self.expense.analytic_distribution = {self.analytic_account_1.id: 100}
         self.expense._do_approve(check=False)
-        self.expense._post_without_wizard()
+        self._action_post_expense()
         move = self.expense.account_move_id
         tags = move.mapped("line_ids.analytic_line_ids.tag_ids")
         self.assertNotIn(self.analytic_tag_1, tags)
         self.assertNotIn(self.analytic_tag_2, tags)
+
+
+@tagged("-at_install", "post_install")
+class TestHrExpenseAnalyticTagOwnAccount(TestHrExpenseAnalyticTagBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.expense.payment_mode = "own_account"
+
+    def test_hr_expense_with_tag(self):
+        self._test_hr_expense_with_tag()
+
+    def test_hr_expense_with_tags_01(self):
+        self._test_hr_expense_with_tags_01()
+
+    def test_hr_expense_with_tags_02(self):
+        self._test_hr_expense_with_tags_02()
+
+    def test_hr_expense_with_tags_03(self):
+        self._test_hr_expense_with_tags_03()
+
+    def test_hr_expense_without_tags(self):
+        self._test_hr_expense_without_tags()
+
+
+@tagged("-at_install", "post_install")
+class TestHrExpenseAnalyticTagCompanyAccount(TestHrExpenseAnalyticTagBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.expense.payment_mode = "company_account"
+
+    def test_hr_expense_with_tag(self):
+        self._test_hr_expense_with_tag()
+
+    def test_hr_expense_with_tags_01(self):
+        self._test_hr_expense_with_tags_01()
+
+    def test_hr_expense_with_tags_02(self):
+        self._test_hr_expense_with_tags_02()
+
+    def test_hr_expense_with_tags_03(self):
+        self._test_hr_expense_with_tags_03()
+
+    def test_hr_expense_without_tags(self):
+        self._test_hr_expense_without_tags()


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/account-analytic/pull/955

Add payment_mode=company_account compatibility

This compatibility exists in v16 https://github.com/OCA/account-analytic/pull/766, but when it was merged, it was not added to https://github.com/OCA/account-analytic/pull/760

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT64075