### PR TITLE
[19.0][IMP] hr_expense_analytic_tag: Do not allow the field to be modified if is_editable

### DIFF
--- a/hr_expense_analytic_tag/views/hr_expense_view.xml
+++ b/hr_expense_analytic_tag/views/hr_expense_view.xml
@@ -11,6 +11,7 @@
                     groups="account_analytic_tag.group_analytic_tags"
                     widget="many2many_tags"
                     options="{'color_field': 'color'}"
+                    readonly="not is_editable"
                 />
             </field>
         </field>


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/account-analytic/pull/954

Do not allow the field to be modified if `is_editable`

The `readonly="not is_editable"` attribute is used in all fields; therefore, it must also be used in the `analytic_tag_ids` field

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa