### PR TITLE
[UPD] Update oca-addons-repo-template to v1.43

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,8 +1,7 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.39
+_commit: v1.43
 _src_path: git+https://github.com/OCA/oca-addons-repo-template
 additional_ruff_rules: []
-ci: GitHub
 convert_readme_fragments_to_markdown: true
 enable_checklog_odoo: true
 generate_requirements_txt: true
@@ -17,6 +16,7 @@ odoo_test_flavor: Both
 odoo_version: 19.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
+postgres_image: ''
 rebel_module_groups: []
 repo_description: account-analytic
 repo_name: account-analytic

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+
 name: pre-commit
 
 on:
@@ -16,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: 'pip'
           cache-dependency-path: '.pre-commit-config.yaml'
       - name: Get python version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,6 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
-    env:
-      OCA_ENABLE_CHECKLOG_ODOO: "1"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.12
   node: "22.9.0"
 repos:
   - repo: local
@@ -38,6 +38,11 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+      - id: obsolete dotfiles
+        name: obsolete dotfiles
+        entry: found obsolete files; remove them
+        files: '^(\.travis\.yml|\.t2d\.yml|CONTRIBUTING\.md|\.prettierrc\.yml|\.eslintrc\.yml)$'
+        language: fail
   - repo: https://github.com/sbidoul/whool
     rev: v1.3
     hooks:


### PR DESCRIPTION
## Summary
- Bumps the OCA repo template (`.copier-answers.yml` `_commit`) from v1.39 to v1.43.
- Extracted as a standalone template-only update from the `account_analytic_distribution_manual` 19.0 migration in weinni2000/account-analytic#1, as suggested in review, since these files are copier-managed and unrelated to the module migration itself.

## Changes
- `.copier-answers.yml`: bump `_commit`, drop `ci: GitHub`, add `postgres_image: ''`
- `.github/workflows/pre-commit.yml`: bump Python to 3.12
- `.github/workflows/test.yml`: drop `OCA_ENABLE_CHECKLOG_ODOO` env var
- `.pre-commit-config.yaml`: pin `python3.12`, add "obsolete dotfiles" hook
- `checklog-odoo.cfg`: removed (no longer used)