### PR TITLE
[18.0][FIX] analytic_base_department: fix analytic line form view and add optional attribute to fields on list view

### DIFF
--- a/analytic_base_department/views/analytic.xml
+++ b/analytic_base_department/views/analytic.xml
@@ -46,10 +46,13 @@
         <field name="model">account.analytic.line</field>
         <field name="inherit_id" ref="analytic.view_account_analytic_line_form" />
         <field name="arch" type="xml">
-            <field name="company_id" position="after">
+            <xpath
+                expr="//group[@name='analytic_item']/field[@name='company_id']"
+                position="after"
+            >
                 <field name="department_id" />
                 <field name="account_department_id" />
-            </field>
+            </xpath>
         </field>
     </record>
     <record id="view_account_analytic_line_tree" model="ir.ui.view">
@@ -58,8 +61,8 @@
         <field name="inherit_id" ref="analytic.view_account_analytic_line_tree" />
         <field name="arch" type="xml">
             <field name="company_id" position="after">
-                <field name="department_id" />
-                <field name="account_department_id" />
+                <field name="department_id" optional="show" />
+                <field name="account_department_id" optional="show" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Fix the form view (there is an invisible `company_id` field at the beginning of the original form) and added `optional` attribute to the fields in the analytic lines list view